### PR TITLE
chore: enforce Array<T> via oxlint typescript/array-type rule

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -26,6 +26,7 @@ export default defineConfig({
     'no-else-return': 'error',
     'default-param-last': 'error',
     'prefer-exponentiation-operator': 'error',
+    'typescript/array-type': ['error', { default: 'generic' }],
     'typescript/consistent-type-imports': ['error', { disallowTypeAnnotations: false }],
     'typescript/no-inferrable-types': 'error',
     'typescript/prefer-function-type': 'error',


### PR DESCRIPTION
## Summary

- Adds `typescript/array-type` to oxlint config with `default: 'generic'`, enforcing `Array<T>` instead of `T[]`.
- No existing violations in this repo — config-only change.

## Test plan

- [ ] `pnpm lint` is clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01YGA78Pm3Ud1Q1VPQp1Crdz)_