### PR TITLE
feat: add /implement command to spec-driven workflow

### DIFF
--- a/.agents/skills/spec-driven/SKILL.md
+++ b/.agents/skills/spec-driven/SKILL.md
@@ -19,8 +19,9 @@ own folder `plans/<feature>/`. Blank templates live in `plans/templates/`, and t
 3. **Plan** (`plans/<feature>/plan.md`): the architecture and a breakdown into numbered slices,
    each demonstrable on its own. Run `/plan <feature>`. Scaffold each slice from
    `plans/templates/slice.md` into `plans/<feature>/NNN-<slug>.md`.
-4. **Execute**: implement one slice at a time until its done criteria pass, and keep each slice
-   runnable.
+4. **Execute** (`plans/<feature>/NNN-<slug>.md`): implement one slice at a time, ticking each
+   slice's Done criteria as its verification passes, and keep each slice runnable. Run
+   `/implement <feature>`.
 5. **Verify** (`plans/<feature>/verification.md`): walk end-to-end scenarios, each mapped back
    to an `AC-N`. Run `/verify <feature>`.
 

--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -1,0 +1,18 @@
+---
+argument-hint: <feature>
+description: Work a feature's slices one at a time, ticking each slice's Done criteria as it passes
+---
+
+Execute the slices for **$ARGUMENTS** from `plans/$ARGUMENTS/plan.md` and its
+`NNN-<slug>.md` slice files.
+
+1. Confirm `plans/$ARGUMENTS/plan.md` and at least one slice file exist. If not, run `/plan` first.
+2. Work the slices in numbered order, one at a time. For each slice: follow its Steps, then run
+   its Verification commands. Keep the slice runnable before moving on.
+3. When a slice's Verification passes, tick its Done criteria in that slice file (`- [ ]` to
+   `- [x]`).
+4. If a slice's Verification fails, fix it or stop and report; do not check unmet criteria or
+   start the next slice.
+5. Once every slice's Done criteria pass, run `/verify $ARGUMENTS` for the feature-level closeout.
+
+This is the Execute step of the `spec-driven` skill.

--- a/plans/README.md
+++ b/plans/README.md
@@ -33,14 +33,14 @@ plans/
 | 0 Specify | `<feature>/spec.md` | Requirements (`FR-N`) and acceptance criteria (`AC-N`). Behavior, not code. |
 | 1 Research | `<feature>/research.md` | Decisions with reasoning, open questions, operating constraints. |
 | 2 Plan | `<feature>/plan.md` | Architecture and the breakdown into numbered slices. |
-| Execute | `<feature>/NNN-<slug>.md` | One file per slice, copied from `templates/slice.md`. Implement one at a time. |
+| Execute | `<feature>/NNN-<slug>.md` | One file per slice, copied from `templates/slice.md`. Implement one at a time, ticking Done criteria as each passes. |
 | Verify | `<feature>/verification.md` | End-to-end scenarios, each mapped back to an `AC-N`. |
 
 ## How to use it
 
 1. `/spec <feature>` creates `plans/<feature>/spec.md`.
 2. `/plan <feature>` turns the spec and research into `plan.md` and scaffolds the slice files.
-3. Implement each `NNN-<slug>.md` slice until its done criteria pass.
+3. `/implement <feature>` works each `NNN-<slug>.md` slice in order, ticking its Done criteria as the slice passes.
 4. `/verify <feature>` fills and runs `verification.md`.
 
 The `spec-driven` skill explains the same flow and when to reach for it.


### PR DESCRIPTION
## Summary

The spec-driven workflow had a slash command for every phase except Execute (`/spec`, `/plan`, `/verify`), so the slice Done criteria checkboxes in `plans/<feature>/NNN-<slug>.md` were updated by hand with no consistent driver.

This adds a dedicated `/implement <feature>` command that owns the Execute phase: it works slices in numbered order, runs each slice's Verification, and ticks that slice's Done criteria as it passes. This matches GitHub Spec Kit's `/speckit.implement` step. `/verify` is unchanged and stays the feature-level closeout mapped to `AC-N`.

- Add `.claude/commands/implement.md`
- Update `.agents/skills/spec-driven/SKILL.md` Phase 4 to name the command and the Done-criteria behavior
- Update `plans/README.md` Phases table and "How to use it" so the flow reads spec, plan, implement, verify

## Test plan

- [ ] `/implement` shows in the command list with the new description
- [ ] `grep -rn "implement" plans/README.md .agents/skills/spec-driven/SKILL.md` shows consistent references
- [ ] `pnpm format && pnpm lint` pass

https://claude.ai/code/session_01HEELJSu2fPo8n6FZAJphKq

---
_Generated by [Claude Code](https://claude.ai/code/session_01HEELJSu2fPo8n6FZAJphKq)_