### PR TITLE
docs: prefer type over interface and object params in code style

### DIFF
--- a/.claude/rules/code-style.md
+++ b/.claude/rules/code-style.md
@@ -19,15 +19,8 @@ rule.
 
 ## Comments
 
-Any prose inside the codebase (inline `//` comments, JSDoc blocks, README-style headers in code
-files) follows the house voice. The `humanizer` skill is the full reference.
-
-- No dashes as punctuation (em, en, or a spaced hyphen). Use a period, comma, parentheses, or
-  a separate sentence.
-- No clause-joining semicolons. Use two sentences or a comma + conjunction.
-- Be specific; cut filler and AI-isms ("in order to", "utilize", "leverage", "seamless").
-- Default to writing no comments. Only add one when the WHY is non-obvious. See the JSDoc rule
-  for what to document on exported members.
+- Prose in code (inline `//`, JSDoc, headers) follows the house voice (`humanizer` skill)
+- Default to no comments. Add one only when the WHY is non-obvious
 
 ## Naming
 
@@ -48,10 +41,8 @@ files) follows the house voice. The `humanizer` skill is the full reference.
 - Expose the public API through the `"exports"` map and `typesVersions`. Keep it stable
 - Define types at the file root, not inside functions
 - Use function syntax (not arrow functions) for object methods so `this` works
-- Use `type` instead of `interface`. Reserve `interface` for declaration merging, like
-  augmenting a global in a `.d.ts`
-- When a function takes two or more parameters, pass a single object instead of positional
-  arguments
+- Use `type`, not `interface` (reserve `interface` for declaration merging in `.d.ts`)
+- Functions with two or more parameters take a single object
 
 ## Tests
 

--- a/.claude/rules/code-style.md
+++ b/.claude/rules/code-style.md
@@ -36,6 +36,10 @@ rule.
 - Expose the public API through the `"exports"` map and `typesVersions`. Keep it stable
 - Define types at the file root, not inside functions
 - Use function syntax (not arrow functions) for object methods so `this` works
+- Use `type` instead of `interface`. Reserve `interface` for declaration merging, like
+  augmenting a global in a `.d.ts`
+- When a function takes two or more parameters, pass a single object instead of positional
+  arguments
 
 ## Tests
 

--- a/.claude/rules/code-style.md
+++ b/.claude/rules/code-style.md
@@ -19,7 +19,9 @@ rule.
 
 ## Comments
 
-- Default to none, add one only when the WHY is non-obvious. Prose follows the house voice (`humanizer` skill)
+- Default to no comments
+- Add one only when the WHY is non-obvious
+- Follow the house voice (`humanizer` skill)
 
 ## Naming
 

--- a/.claude/rules/code-style.md
+++ b/.claude/rules/code-style.md
@@ -19,8 +19,7 @@ rule.
 
 ## Comments
 
-- Prose in code (inline `//`, JSDoc, headers) follows the house voice (`humanizer` skill)
-- Default to no comments. Add one only when the WHY is non-obvious
+- Default to none, add one only when the WHY is non-obvious. Prose follows the house voice (`humanizer` skill)
 
 ## Naming
 

--- a/.claude/rules/code-style.md
+++ b/.claude/rules/code-style.md
@@ -17,6 +17,18 @@ rule.
 - Prefer functional patterns
 - Keep ternaries one level deep. For nested conditions use if/else or extract a helper
 
+## Comments
+
+Any prose inside the codebase (inline `//` comments, JSDoc blocks, README-style headers in code
+files) follows the house voice. The `humanizer` skill is the full reference.
+
+- No dashes as punctuation (em, en, or a spaced hyphen). Use a period, comma, parentheses, or
+  a separate sentence.
+- No clause-joining semicolons. Use two sentences or a comma + conjunction.
+- Be specific; cut filler and AI-isms ("in order to", "utilize", "leverage", "seamless").
+- Default to writing no comments. Only add one when the WHY is non-obvious. See the JSDoc rule
+  for what to document on exported members.
+
 ## Naming
 
 | Context                | Convention  |

--- a/.claude/rules/jsdoc.md
+++ b/.claude/rules/jsdoc.md
@@ -19,4 +19,4 @@ Minimal, high-quality JSDoc. For the full format guide and examples, use the `js
 
 ## Voice
 
-- JSDoc is prose, so it follows the house voice (`humanizer` skill)
+- Follow the house voice (`humanizer` skill)

--- a/.claude/rules/jsdoc.md
+++ b/.claude/rules/jsdoc.md
@@ -16,3 +16,15 @@ Minimal, high-quality JSDoc. For the full format guide and examples, use the `js
 - Use `@example` for complex or multi-variant APIs, one concern per example, code on its own line
 - Do not use `@param`, `@returns`, `@type`, or `@typedef`, since TypeScript already provides these
 - Do not over-document trivial, self-explanatory members
+
+## Voice
+
+JSDoc is prose, so it follows the same house voice as chat replies, markdown files, and inline
+code comments. The `humanizer` skill is the full reference.
+
+- No dashes as punctuation (em, en, or a spaced hyphen). Use a period, comma, parentheses, or
+  a separate sentence. Hyphenated compounds (`request-scoped`, `four-byte`) are fine.
+- No clause-joining semicolons. Two short sentences read better than one long compound.
+- Do not lead a route or operation block with ``` `GET /foo` — description ```. Write
+  ``` `GET /foo`. Description. ``` instead.
+- Sentence-case, no marketing words, cut filler.

--- a/.claude/rules/jsdoc.md
+++ b/.claude/rules/jsdoc.md
@@ -19,5 +19,4 @@ Minimal, high-quality JSDoc. For the full format guide and examples, use the `js
 
 ## Voice
 
-- JSDoc is prose, so it follows the house voice (`humanizer` skill): no dashes or clause-joining
-  semicolons, sentence-case, no filler. Hyphenated compounds (`request-scoped`) are fine
+- JSDoc is prose, so it follows the house voice (`humanizer` skill)

--- a/.claude/rules/jsdoc.md
+++ b/.claude/rules/jsdoc.md
@@ -19,12 +19,5 @@ Minimal, high-quality JSDoc. For the full format guide and examples, use the `js
 
 ## Voice
 
-JSDoc is prose, so it follows the same house voice as chat replies, markdown files, and inline
-code comments. The `humanizer` skill is the full reference.
-
-- No dashes as punctuation (em, en, or a spaced hyphen). Use a period, comma, parentheses, or
-  a separate sentence. Hyphenated compounds (`request-scoped`, `four-byte`) are fine.
-- No clause-joining semicolons. Two short sentences read better than one long compound.
-- Do not lead a route or operation block with ``` `GET /foo` — description ```. Write
-  ``` `GET /foo`. Description. ``` instead.
-- Sentence-case, no marketing words, cut filler.
+- JSDoc is prose, so it follows the house voice (`humanizer` skill): no dashes or clause-joining
+  semicolons, sentence-case, no filler. Hyphenated compounds (`request-scoped`) are fine

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -14,12 +14,9 @@ How to write, run, and debug tests in this repo (Vitest).
 - Test one behaviour per case and name it for the expected outcome ("returns X when Y")
 - Keep tests isolated and repeatable: no shared mutable state, clean up side effects in `afterEach`
 - Mock external dependencies (network, filesystem, time), not internal modules
-- Prefer a scoped spy with `using _ = vi.spyOn(...)` inside each test over a module-level
-  `vi.mock` plus `beforeEach(mockReset)`. The `using` binding restores the spy when the test
-  scope ends, so there is no shared mock state to reset
+- Prefer a scoped `using _ = vi.spyOn(...)` per test over module-level `vi.mock` + `beforeEach(mockReset)`
 - Use `vi.useFakeTimers()` and `vi.setSystemTime()` for time-dependent logic
-- For assertions, pin a full shape with `toMatchInlineSnapshot()` and check a partial shape
-  with `toMatchObject({ ... })`
+- Assert full shapes with `toMatchInlineSnapshot()`, partial shapes with `toMatchObject({ ... })`
 - Treat snapshots as intentional: review every change and update with `-u` only when expected
 - Assert on public behaviour and output, not private implementation details
 - Keep unit tests fast, and reserve `pnpm test:bench` for performance-sensitive code

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -14,9 +14,10 @@ How to write, run, and debug tests in this repo (Vitest).
 - Test one behaviour per case and name it for the expected outcome ("returns X when Y")
 - Keep tests isolated and repeatable: no shared mutable state, clean up side effects in `afterEach`
 - Mock external dependencies (network, filesystem, time), not internal modules
-- Prefer a scoped `using _ = vi.spyOn(...)` per test over module-level `vi.mock` + `beforeEach(mockReset)`
+- Spy per test with `using _ = vi.spyOn(...)`, not module-level `vi.mock` + `beforeEach(mockReset)`
 - Use `vi.useFakeTimers()` and `vi.setSystemTime()` for time-dependent logic
-- Assert full shapes with `toMatchInlineSnapshot()`, partial shapes with `toMatchObject({ ... })`
+- Full shape: `toMatchInlineSnapshot()`
+- Partial shape: `toMatchObject({ ... })`
 - Treat snapshots as intentional: review every change and update with `-u` only when expected
 - Assert on public behaviour and output, not private implementation details
 - Keep unit tests fast, and reserve `pnpm test:bench` for performance-sensitive code

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -14,7 +14,12 @@ How to write, run, and debug tests in this repo (Vitest).
 - Test one behaviour per case and name it for the expected outcome ("returns X when Y")
 - Keep tests isolated and repeatable: no shared mutable state, clean up side effects in `afterEach`
 - Mock external dependencies (network, filesystem, time), not internal modules
+- Prefer a scoped spy with `using _ = vi.spyOn(...)` inside each test over a module-level
+  `vi.mock` plus `beforeEach(mockReset)`. The `using` binding restores the spy when the test
+  scope ends, so there is no shared mock state to reset
 - Use `vi.useFakeTimers()` and `vi.setSystemTime()` for time-dependent logic
+- For assertions, pin a full shape with `toMatchInlineSnapshot()` and check a partial shape
+  with `toMatchObject({ ... })`
 - Treat snapshots as intentional: review every change and update with `-u` only when expected
 - Assert on public behaviour and output, not private implementation details
 - Keep unit tests fast, and reserve `pnpm test:bench` for performance-sensitive code


### PR DESCRIPTION
## Summary

Adds two conventions to the always-on code-style rule:

- Use `type` instead of `interface`, reserving `interface` for declaration merging (such as augmenting a global in a `.d.ts`).
- When a function takes two or more parameters, pass a single object instead of positional arguments.

The existing source already follows both. The only `interface` uses in the repo are in `env.d.ts` and `reset.d.ts`, which rely on declaration merging and must stay as `interface`, so no source refactor was needed.

## Test plan

- [ ] No code changed, docs-only update to `.claude/rules/code-style.md`

https://claude.ai/code/session_01PhM5YRUoQCWAAu4NgLXToT

---
_Generated by [Claude Code](https://claude.ai/code/session_01PhM5YRUoQCWAAu4NgLXToT)_