### PR TITLE
docs: use US English spelling and drop cspell words dictionary

### DIFF
--- a/.agents/skills/jsdoc/SKILL.md
+++ b/.agents/skills/jsdoc/SKILL.md
@@ -148,7 +148,7 @@ Only add JSDoc when it adds value beyond the signature:
 // No JSDoc needed: the signature is self-explanatory
 function camelCase(str: string): string { ... }
 
-// JSDoc adds value: it explains behaviour and non-obvious edge cases
+// JSDoc adds value: it explains behavior and non-obvious edge cases
 /**
  * Returns `true` when the schema resolves to a plain string output.
  *
@@ -181,7 +181,7 @@ Do not:
 ## Tag order
 
 1. Description (required)
-2. Bullet list of variants or behaviours (if applicable)
+2. Bullet list of variants or behaviors (if applicable)
 3. `@default` (if non-obvious)
 4. `@example` (one or more)
 5. `@note` (if needed)

--- a/.claude/output-styles/plan.md
+++ b/.claude/output-styles/plan.md
@@ -28,7 +28,7 @@ For a pattern repeated across many files, describe it once with a few representa
 
 ## Verification
 
-How to confirm the change works end to end: commands to run, tests to add, behaviour to observe.
+How to confirm the change works end to end: commands to run, tests to add, behavior to observe.
 
 ## Open questions
 

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -11,7 +11,7 @@ How to write, run, and debug tests in this repo (Vitest).
 ## Authoring
 
 - Colocate tests next to source as `*.test.ts` or `*.test.tsx` in `src`
-- Test one behaviour per case and name it for the expected outcome ("returns X when Y")
+- Test one behavior per case and name it for the expected outcome ("returns X when Y")
 - Keep tests isolated and repeatable: no shared mutable state, clean up side effects in `afterEach`
 - Mock external dependencies (network, filesystem, time), not internal modules
 - Spy per test with `using _ = vi.spyOn(...)`, not module-level `vi.mock` + `beforeEach(mockReset)`
@@ -19,7 +19,7 @@ How to write, run, and debug tests in this repo (Vitest).
 - Full shape: `toMatchInlineSnapshot()`
 - Partial shape: `toMatchObject({ ... })`
 - Treat snapshots as intentional: review every change and update with `-u` only when expected
-- Assert on public behaviour and output, not private implementation details
+- Assert on public behavior and output, not private implementation details
 - Keep unit tests fast, and reserve `pnpm test:bench` for performance-sensitive code
 
 ## Running and CI

--- a/cspell.json
+++ b/cspell.json
@@ -18,5 +18,27 @@
   "ignoreRegExpList": [
     "https?://github\\.com/[a-zA-Z0-9-_]+(/[a-zA-Z0-9-_]+)?",
     "\\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Z|a-z]{2,}\\b"
+  ],
+  "words": [
+    "stijnvanhulle",
+    "Stijn",
+    "Hulle",
+    "Turborepo",
+    "monorepo",
+    "codegen",
+    "Oxlint",
+    "Oxfmt",
+    "oxfmt",
+    "oxlint",
+    "Vitest",
+    "Vitepress",
+    "tsdown",
+    "Github",
+    "changesets",
+    "codecov",
+    "rolldown",
+    "taze",
+    "pkg-pr-new",
+    "rharkor"
   ]
 }

--- a/cspell.json
+++ b/cspell.json
@@ -18,27 +18,5 @@
   "ignoreRegExpList": [
     "https?://github\\.com/[a-zA-Z0-9-_]+(/[a-zA-Z0-9-_]+)?",
     "\\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Z|a-z]{2,}\\b"
-  ],
-  "words": [
-    "stijnvanhulle",
-    "Stijn",
-    "Hulle",
-    "organisation",
-    "Turborepo",
-    "monorepo",
-    "Oxlint",
-    "Oxfmt",
-    "oxfmt",
-    "oxlint",
-    "Vitest",
-    "Vitepress",
-    "tsdown",
-    "Github",
-    "changesets",
-    "codecov",
-    "rolldown",
-    "taze",
-    "pkg-pr-new",
-    "rharkor"
   ]
 }


### PR DESCRIPTION
## Summary

- Replace British "behaviour"/"behaviours" with "behavior"/"behaviors" in `.claude/output-styles/plan.md`, `.claude/rules/testing.md`, and `.agents/skills/jsdoc/SKILL.md`.
- Remove the British spelling `organisation` from the `cspell.json` `words` array. Tool and proper-noun entries are kept so spell check stays green, and `codegen` (already used in `plans/templates/verification.md`) is added.
- Left `.agents/skills/documentation/SKILL.md` untouched: its "use license, not licence" line is an intentional counterexample.

## Test plan

- [ ] `grep -rEn "behaviour" --include="*.md" -i .` returns nothing
- [ ] `pnpm lint:spell` passes (0 issues)

https://claude.ai/code/session_01BoTSMQtVwxHVrA12jVZ8UU