### PR TITLE
docs: trigger humanizer skill on markdown edits

### DIFF
--- a/.claude/rules/markdown.md
+++ b/.claude/rules/markdown.md
@@ -18,3 +18,9 @@ the `documentation` skill. This rule adds only the markdown-structure specifics:
 
 `docs/changelog.md` follows the `changelog` skill's emoji-prefixed section format
 (`### ✨ Features`, `🐛 Bug Fixes`, `🚀 Breaking Changes`, `📦 Dependencies`).
+
+## Before committing
+
+Run the `humanizer` skill over any user-facing markdown you write or edit (READMEs, docs,
+changesets, plugin copy) and fix the tells it surfaces in that same pass. Do this by default as
+part of writing the file, not only when asked.

--- a/.claude/rules/markdown.md
+++ b/.claude/rules/markdown.md
@@ -22,5 +22,5 @@ the `documentation` skill. This rule adds only the markdown-structure specifics:
 ## Before committing
 
 Run the `humanizer` skill over any user-facing markdown you write or edit (READMEs, docs,
-changesets, plugin copy) and fix the tells it surfaces in that same pass. Do this by default as
+changesets) and fix the tells it surfaces in that same pass. Do this by default as
 part of writing the file, not only when asked.


### PR DESCRIPTION
Adds a "Before committing" section to `.claude/rules/markdown.md` so any user-facing markdown change runs the `humanizer` skill in the same pass.

```
## Before committing

Run the `humanizer` skill over any user-facing markdown you write or edit (READMEs, docs,
changesets, plugin copy) and fix the tells it surfaces in that same pass. Do this by default as
part of writing the file, not only when asked.
```

https://claude.ai/code/session_016nrw3PgaKC2oSuNVbwsgim

---
_Generated by [Claude Code](https://claude.ai/code/session_016nrw3PgaKC2oSuNVbwsgim)_