### PR TITLE
feat(skills): add diagnose, tdd, prototype, handoff, grill, write-skill, zoom-out

### DIFF
--- a/.agents/skills/diagnose/SKILL.md
+++ b/.agents/skills/diagnose/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: diagnose
+description: "Disciplined debugging loop for hard bugs and performance regressions: reproduce, minimize, hypothesize, instrument, fix, regression-test. Use when the user reports a bug, says something is broken/failing, or describes a performance regression."
+---
+
+# Diagnose
+
+A discipline for hard bugs. Skip phases only when you can justify it.
+
+## Phase 1 - Build a feedback loop
+
+**This is the skill.** Everything else is mechanical. If you have a fast, deterministic, agent-runnable pass/fail signal for the bug, you will find the cause. If you don't, no amount of staring at code will save you.
+
+Ways to construct one, in roughly this order:
+
+1. **Failing test** at whatever seam reaches the bug (Vitest unit, integration, or e2e).
+2. **CLI invocation** with a fixture input, diff stdout against a known-good snapshot.
+3. **Replay a captured trace.** Save a real payload/request to disk, run it through the code in isolation.
+4. **Throwaway harness.** Spin up a minimal subset of the system that triggers the bug with a single function call.
+5. **Property / fuzz loop.** For "sometimes wrong output" bugs, run many random inputs.
+6. **Bisection harness.** If the bug appeared between two known states, automate it so `git bisect run` works.
+7. **Differential loop.** Run the same input through two versions or configs and diff the output.
+
+Iterate on the loop itself: faster, sharper, more deterministic. A 2-second deterministic loop is a debugging superpower.
+
+For non-deterministic bugs, raise the reproduction rate (loop 100x, parallelise, add stress) until the bug is debuggable.
+
+If you genuinely cannot build a loop, stop and say so. List what you tried. Ask the user for a captured artifact or access. Do not proceed to hypothesise without a loop.
+
+## Phase 2 - Reproduce
+
+Run the loop. Watch the bug appear. Confirm:
+
+- [ ] The failure matches what the user described, not a nearby bug
+- [ ] The failure reproduces across runs (or at a high enough rate)
+- [ ] You captured the exact symptom so later phases can verify the fix
+
+## Phase 3 - Hypothesise
+
+Generate **3-5 ranked hypotheses** before testing any of them. Single-hypothesis generation anchors on the first plausible idea.
+
+Each hypothesis must be falsifiable: state the prediction.
+
+> Format: "If X is the cause, then changing Y will make the bug disappear / changing Z will make it worse."
+
+Show the ranked list to the user before testing. They often have domain knowledge that re-ranks instantly. Cheap checkpoint, big time saver.
+
+## Phase 4 - Instrument
+
+Each probe maps to one prediction. **Change one variable at a time.**
+
+- One breakpoint beats ten logs.
+- Use targeted logs at the boundaries that distinguish hypotheses.
+- **Tag every debug log** with a unique prefix like `[DEBUG-a4f2]`. Cleanup at the end is a single grep.
+- For performance, logs are usually wrong: establish a baseline with `performance.now()` or a profiler, then bisect.
+
+## Phase 5 - Fix and regression test
+
+Write the regression test **before the fix**, but only if there is a correct seam: one that exercises the real bug pattern at the right call site. A shallow seam gives false confidence.
+
+If no correct seam exists, that itself is the finding. The architecture is preventing the bug from being locked down. Flag it.
+
+If a correct seam exists: failing test, fix, watch it pass, re-run the Phase 1 loop.
+
+## Phase 6 - Cleanup
+
+- [ ] Original repro no longer reproduces
+- [ ] Regression test passes (or absence is documented)
+- [ ] All `[DEBUG-...]` instrumentation removed (`grep` the prefix)
+- [ ] Throwaway prototypes deleted
+- [ ] The hypothesis that turned out correct is stated in the commit message
+
+Then ask: what would have prevented this bug? If the answer is architectural, surface the specifics.

--- a/.agents/skills/grill/SKILL.md
+++ b/.agents/skills/grill/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: grill
+description: "Interview the user about a plan or design one question at a time, with a recommended answer for each, until every branch of the decision tree is resolved. Use when the user asks to stress-test a plan, says 'grill me', or before committing to a non-trivial design."
+---
+
+# Grill
+
+A structured interview that resolves a design before any code is written.
+
+## How it works
+
+- Ask **one question at a time** and wait for the answer before continuing.
+- For each question, **propose your recommended answer** with the reasoning. The user can accept, adjust, or override.
+- Walk down each branch of the decision tree. Resolve dependencies between decisions in order, so later questions assume the earlier answers.
+- When a question can be answered by reading the code, read the code instead of asking.
+
+## Things to probe
+
+- **Vocabulary** - call out terms that are vague, overloaded, or conflict with how the codebase already uses them. "You said 'account' - do you mean the Customer or the User?"
+- **Edge cases** - invent concrete scenarios that force precision about boundaries. Empty input, concurrent writes, partial failure, the long-tail user.
+- **Contradictions** - if the user's description disagrees with the code, surface it. "Your code cancels whole orders, but you said partial cancellation works - which is right?"
+- **Trade-offs** - when there are real alternatives, name them and ask which trade-off we're accepting.
+
+## When to stop
+
+When the next question is no longer changing anything: answers are predictable from earlier ones, and you and the user agree on the shape of the thing.
+
+## After the session
+
+- If the result is large enough to warrant a paper trail, hand off to `spec-driven` and capture the decisions in `plans/<feature>/spec.md` and `research.md`.
+- If it's a small change, summarise the decisions in the commit or PR description so the reasoning is preserved.
+
+## Related skills
+
+| Skill | Use for |
+| --- | --- |
+| [spec-driven](../spec-driven/SKILL.md) | Capture the grilled plan as a spec + slices |
+| [prototype](../prototype/SKILL.md) | When a question is faster to answer with code than with discussion |

--- a/.agents/skills/handoff/SKILL.md
+++ b/.agents/skills/handoff/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: handoff
+description: "Write a handoff document that compresses the current session for the next agent or session. Use when context is getting long, when switching tasks, or before ending a session that another agent will pick up."
+---
+
+# Handoff
+
+Condense the current conversation into a compact document the next session can read cold.
+
+## Where to write
+
+Default: `plans/<feature>/handoff.md` if a feature folder exists, otherwise `plans/handoff-<short-slug>.md`. Commit it - the goal is durable context, not scratch state.
+
+## What to include
+
+- **Goal** - one sentence on what we're trying to do.
+- **Status** - what's done, what's in progress, what's blocked.
+- **Key decisions** - decisions taken and the reasoning, with links to ADRs, PRDs, or `research.md` rather than copying the content.
+- **Open questions** - things the next session must decide before continuing.
+- **Pointers** - paths and line numbers for the relevant code, the PR or branch name, the failing test if any.
+- **Suggested skills** - which skills in `.agents/skills/` the next agent should read first.
+
+## What to leave out
+
+- Full file contents that already exist on disk - reference paths instead.
+- Long quoted conversation history - summarise outcomes.
+- Secrets, tokens, or PII - redact.
+
+## Format
+
+Keep it under one screen. If it doesn't fit, the next agent won't read it. Use short bulleted sections, not prose.
+
+## After writing
+
+Return the path to the user and a one-line summary. If the conversation is ending, also note the branch name and the next concrete action.

--- a/.agents/skills/prototype/SKILL.md
+++ b/.agents/skills/prototype/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: prototype
+description: "Build a throwaway prototype to answer a single design question (logic or UI) before committing to production code. Use when a design choice is uncertain and a quick experiment would resolve it faster than discussion."
+---
+
+# Prototype
+
+A prototype is **throwaway code that answers a question.** The question determines the shape.
+
+## Two branches
+
+**Logic** - validating state machines or business logic. Build a minimal interactive script that stress-tests scenarios. Print full state after every step so transitions are visible.
+
+**UI** - exploring visual or interaction directions. Generate several distinct variations toggleable from one entry point (URL query param, env var, CLI flag).
+
+## Rules
+
+1. Mark prototypes clearly as temporary. Place them near the production code they relate to (e.g. `packages/<pkg>/prototypes/`).
+2. One command launches it. No setup ceremony.
+3. No persistence unless persistence is what you're testing. Keep state in memory.
+4. Skip tests, error handling, and abstractions. They obscure the answer.
+5. Show the full state after every interaction so changes stay visible.
+
+## Resolution
+
+Once the prototype answers its question:
+
+- Delete it, or
+- Move the validated finding into production code and delete the prototype.
+
+Before deletion, write the question and the answer somewhere durable: a comment on the resulting code, a paragraph in an ADR or `plans/<feature>/research.md`, or a commit message. The artifact disappears; the learning shouldn't.
+
+## Related skills
+
+| Skill | Use for |
+| --- | --- |
+| [spec-driven](../spec-driven/SKILL.md) | Capture the prototype's answer in `research.md` |
+| [tdd](../tdd/SKILL.md) | Build the production version with tests after the prototype answers the question |

--- a/.agents/skills/tdd/SKILL.md
+++ b/.agents/skills/tdd/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: tdd
+description: "Test-driven development with vertical slices for Vitest: one test, one implementation, repeat. Use when adding a new behavior, fixing a bug with a regression test, or designing a public interface."
+---
+
+# TDD
+
+Tests verify behavior through public interfaces, not implementation details. Code can change entirely; tests shouldn't.
+
+## Anti-pattern: horizontal slices
+
+**DO NOT write all tests first, then all implementation.** Bulk-written tests describe imagined behavior, not real behavior. They couple to data shapes and become insensitive to real changes.
+
+```
+WRONG (horizontal):
+  RED:   test1, test2, test3
+  GREEN: impl1, impl2, impl3
+
+RIGHT (vertical):
+  RED -> GREEN: test1 -> impl1
+  RED -> GREEN: test2 -> impl2
+```
+
+Each test responds to what the previous cycle taught you.
+
+## Workflow
+
+### 1. Plan
+
+Before any code:
+
+- [ ] Confirm what interface changes are needed
+- [ ] Confirm which behaviors to test, prioritised
+- [ ] Design the interface for testability (small surface, deep implementation)
+- [ ] List behaviors to test, not implementation steps
+
+Ask: "What should the public interface look like? Which behaviors matter most?"
+
+You cannot test everything. Focus on critical paths and complex logic.
+
+### 2. Tracer bullet
+
+Write ONE test that confirms ONE thing:
+
+```
+RED:   write test for first behavior -> fails
+GREEN: minimal code to pass -> passes
+```
+
+Proves the path works end-to-end.
+
+### 3. Incremental loop
+
+For each remaining behavior:
+
+- One test at a time
+- Only enough code to pass the current test
+- Don't anticipate future tests
+- Keep tests focused on observable behavior
+
+### 4. Refactor
+
+After all tests pass, look for cleanup:
+
+- Extract duplication
+- Deepen modules (move complexity behind simple interfaces)
+- Run tests after each refactor step
+
+**Never refactor while RED.** Get to GREEN first.
+
+## Per-cycle checklist
+
+- [ ] Test describes behavior, not implementation
+- [ ] Test uses public interface only
+- [ ] Test would survive an internal refactor
+- [ ] Code is minimal for this test
+- [ ] No speculative features added
+
+## Commands
+
+```bash
+pnpm test            # full suite
+pnpm test --watch    # tight TDD loop
+pnpm test <pattern>  # focus while iterating
+```
+
+## Related skills
+
+| Skill | Use for |
+| --- | --- |
+| [diagnose](../diagnose/SKILL.md) | Reproducing a bug before writing the regression test |
+| [spec-driven](../spec-driven/SKILL.md) | When the feature is large enough to need a spec first |

--- a/.agents/skills/write-skill/SKILL.md
+++ b/.agents/skills/write-skill/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: write-skill
+description: "Author a new skill in .agents/skills/. Use when the user asks to add, create, or write a new skill, or when a recurring workflow keeps showing up and deserves to be captured."
+---
+
+# Write a skill
+
+Skills live in `.agents/skills/<name>/SKILL.md` and are cross-provider. The `name` and `description` in the frontmatter are the only things an agent sees when deciding whether to load the skill - they do the heavy lifting.
+
+## File layout
+
+```
+.agents/skills/<name>/
+├── SKILL.md           # required, the entry point
+├── references/        # optional, longer reference docs split out
+└── examples/          # optional, concrete examples
+```
+
+Keep `SKILL.md` under ~100 lines. Split deeper material into `references/*.md` and link to them.
+
+## Frontmatter
+
+```yaml
+---
+name: <kebab-case-name>
+description: "<one or two sentences: what it does + when to use it>"
+---
+```
+
+The description is a selection signal. Always state **when to use it** explicitly - phrases like "Use when...", "Use after...", or "Use before..." so the agent can route correctly. Avoid time-sensitive language ("the new X") and avoid restating the name.
+
+## Body structure
+
+1. **One-line summary** restating the purpose in the body's voice.
+2. **When to use** - bullets of concrete triggers, including the inverse ("skip this for trivial changes").
+3. **How it works** - the steps, rules, or checklist that make the skill executable.
+4. **Checklist** (optional) - copy-pasteable Done criteria.
+5. **Related skills** - a small table pointing at sibling skills the agent should consider instead or after.
+
+## Quality bar
+
+- Concrete over abstract. One worked example beats three paragraphs of theory.
+- Imperative voice ("Do X", not "You should do X").
+- Match the repo's tone: short, no fluff, no filler.
+- Run `pnpm format` after writing so markdown wraps cleanly.
+
+## After writing
+
+- Add the skill to the `<skills>` block in `AGENTS.md` so it shows up in the index.
+- Open the file in `.claude/skills/` (a symlink to `.agents/skills/`) to confirm it loads.
+- If the skill replaces or overlaps with an existing one, link the two in the Related skills tables.

--- a/.agents/skills/zoom-out/SKILL.md
+++ b/.agents/skills/zoom-out/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: zoom-out
+description: "Step up a layer of abstraction and map the relevant modules and callers, instead of diving into one file. Use when unfamiliar with an area of code, when a fix keeps growing, or before making a non-local change."
+---
+
+# Zoom out
+
+When the next change isn't obvious from one file, stop and map the surroundings.
+
+## What to produce
+
+- The **module map** for the area: which packages/files own this concern, which depend on it, which it depends on.
+- The **call graph** at the level that matters: who calls the function/type/feature in question, and from where.
+- The **vocabulary**: name each concept using the project's existing terms. If two terms collide, flag it.
+- The **constraint surface**: tests, types, ADRs, or `CONTEXT.md` entries that pin behavior in this area.
+
+## How to do it
+
+1. Start at the entry point the user named (a file, a function, a feature).
+2. Walk **outward** one hop at a time: callers, sibling modules in the same folder, shared types.
+3. Stop when you can describe the area in three to five sentences without hand-waving.
+4. Report the map back **before** proposing a change. A 30-second checkpoint avoids fixing the wrong layer.
+
+## When to skip
+
+- Pure local edits (rename a variable, fix a typo).
+- You already wrote this code in the current session.
+
+## Related skills
+
+| Skill | Use for |
+| --- | --- |
+| [diagnose](../diagnose/SKILL.md) | When the zoom-out reveals the bug is not where you thought |
+| [grill](../grill/SKILL.md) | When the map shows decisions that haven't been made yet |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,9 +74,16 @@ loads.
 You have new skills. If any skill might be relevant then you MUST read it.
 
 - [changelog](.agents/skills/changelog/SKILL.md) - Creates user-facing changelogs from git commits by analyzing commit history, categorizing changes, and transforming technical commits into clear, customer-friendly release notes.
+- [diagnose](.agents/skills/diagnose/SKILL.md) - Disciplined debugging loop for hard bugs and performance regressions: reproduce, minimize, hypothesize, instrument, fix, regression-test. Use when the user reports a bug, says something is broken/failing, or describes a performance regression.
 - [documentation](.agents/skills/documentation/SKILL.md) - Use when writing blog posts or documentation markdown files - provides writing style guide (active voice, present tense), content structure patterns, and SEO optimization. Overrides brevity rules for proper grammar.
+- [grill](.agents/skills/grill/SKILL.md) - Interview the user about a plan or design one question at a time, with a recommended answer for each, until every branch of the decision tree is resolved. Use when the user asks to stress-test a plan, says 'grill me', or before committing to a non-trivial design.
+- [handoff](.agents/skills/handoff/SKILL.md) - Write a handoff document that compresses the current session for the next agent or session. Use when context is getting long, when switching tasks, or before ending a session that another agent will pick up.
 - [humanizer](.agents/skills/humanizer/SKILL.md) - Remove AI writing patterns to make documentation sound natural, specific, and human. Covers content patterns, language patterns, style patterns, and communication patterns.
 - [jsdoc](.agents/skills/jsdoc/SKILL.md) - Full JSDoc format guide for TypeScript, covering @example formats, tag usage (@default, @deprecated, what to avoid), documentation patterns for properties/enums/functions, and tag order.
 - [pr](.agents/skills/pr/SKILL.md) - Rules and checklist for preparing PRs, creating changesets, and releasing packages in the monorepo.
+- [prototype](.agents/skills/prototype/SKILL.md) - Build a throwaway prototype to answer a single design question (logic or UI) before committing to production code. Use when a design choice is uncertain and a quick experiment would resolve it faster than discussion.
 - [spec-driven](.agents/skills/spec-driven/SKILL.md) - Drive a spec-driven workflow for a larger feature: specify requirements and acceptance criteria, research decisions, plan numbered slices, implement, then verify. Use for multi-step features that need a reviewable paper trail. Skip it for small, obvious changes.
+- [tdd](.agents/skills/tdd/SKILL.md) - Test-driven development with vertical slices for Vitest: one test, one implementation, repeat. Use when adding a new behavior, fixing a bug with a regression test, or designing a public interface.
+- [write-skill](.agents/skills/write-skill/SKILL.md) - Author a new skill in .agents/skills/. Use when the user asks to add, create, or write a new skill, or when a recurring workflow keeps showing up and deserves to be captured.
+- [zoom-out](.agents/skills/zoom-out/SKILL.md) - Step up a layer of abstraction and map the relevant modules and callers, instead of diving into one file. Use when unfamiliar with an area of code, when a fix keeps growing, or before making a non-local change.
 </skills>


### PR DESCRIPTION
## Summary

Adapts a curated set of skills from [mattpocock/skills](https://github.com/mattpocock/skills) into this template's `.agents/skills/` layout to broaden the AI-support surface for forks.

Seven new skills, each rewritten to match the template's existing voice and to reference its real stack (Vitest, pnpm, Changesets, `plans/`):

| Skill | What it does |
| --- | --- |
| `diagnose` | Disciplined six-phase debugging loop (reproduce -> minimize -> hypothesize -> instrument -> fix -> regression-test). The headline idea is "the feedback loop is the skill". |
| `tdd` | Vertical-slice TDD for Vitest: one test, one implementation, repeat. Calls out the horizontal-slice anti-pattern. |
| `prototype` | Build throwaway code (logic or UI branch) to answer a single design question, then delete it - preserving only the answer. |
| `handoff` | Compress a session into a short, durable doc for the next agent. Defaults to `plans/<feature>/handoff.md`. |
| `grill` | One-question-at-a-time interview that stress-tests a plan against vocabulary, edge cases, code contradictions, and trade-offs. Natural companion to `spec-driven`. |
| `write-skill` | Meta-skill: how to author new skills in this repo (frontmatter rules, layout, quality bar, AGENTS.md indexing). |
| `zoom-out` | Map modules, callers, vocabulary, and constraints before making a non-local change. |

`AGENTS.md` is updated so the `<skills>` block lists all twelve skills in alphabetical order.

## Notes on what I skipped

From Matt's set I deliberately left out:

- **caveman** - the repo already has `rtk` for token compression; another shorthand-output mode would conflict.
- **improve-codebase-architecture**, **triage**, **to-issues**, **to-prd** - heavier workflow skills better picked à la carte than dropped into a template wholesale.
- **migrate-to-shoehorn**, **scaffold-exercises**, **setup-pre-commit**, **git-guardrails-claude-code** - tool-specific or environment-specific; not template material.

Happy to port any of these too if you want them.

## Test plan

- [ ] `pnpm format` leaves the new markdown unchanged
- [ ] `.claude/skills/` symlink resolves the new SKILL.md files
- [ ] AGENTS.md `<skills>` block lists all twelve skills with correct paths
- [ ] Each new skill has a `description` that starts with what it does and ends with "Use when..."

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rd1yJQKPy6XhFiDdtwoyU2)_