### PR TITLE
ci: continue release:stage on failure and align release flow with kubb

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,8 @@ jobs:
       packages: write
       pull-requests: write
       issues: write
+    outputs:
+      staged: ${{ steps.changesets.outputs.staged }}
     steps:
       - name: Check out code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -47,6 +49,12 @@ jobs:
           node-version: '22'
           cache: 'false'
 
+      - name: Reinstall dependencies (release hardening)
+        # Defense-in-depth: re-install so the release build does not implicitly
+        # trust a pnpm store restored from cache by the composite Setup Tools
+        # step. Lockfile integrity hashes still gate content.
+        run: pnpm install --frozen-lockfile --force
+
       - name: Build
         run: pnpm run build
 
@@ -55,21 +63,61 @@ jobs:
         uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b # v1
         if: ${{ github.event.inputs.tag == '' }}
         with:
-          publish: pnpm release:stage
+          # `release:stage:ci` chains three steps: `release:stage` stages every
+          # package on npm (no publish to `latest`), `changeset tag` creates the
+          # local git tags and prints the `New tag:` lines the action parses to
+          # push tags and create a GitHub Release per package, and the final echo
+          # records that staging ran. It must be a single script: the action
+          # splits `publish` on whitespace and spawns it directly (no shell), so
+          # `&&` and `>>` only work when wrapped in a script pnpm runs via a shell.
+          publish: pnpm release:stage:ci
           commit: 'ci(changesets): version packages'
           setupGitUser: false
         env:
           NPM_CONFIG_PROVENANCE: true
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Stage publish ${{ inputs.tag || 'canary' }}
+      - name: Publish ${{ inputs.tag || 'canary' }}
         id: canary
-        if: steps.changesets.outputs.published != 'true'
+        if: steps.changesets.outputs.staged != 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
           RELEASE_TAG: ${{ inputs.tag || 'canary' }}
+        # Canaries auto-publish straight to npm under their dist-tag via OIDC,
+        # no stage + 2FA approval. They never land on `latest`, so the staging
+        # gate isn't needed and a canary you'd have to approve by hand is useless.
         run: |
           git checkout main
           pnpm version:canary
-          pnpm release:stage --tag "$RELEASE_TAG"
+          pnpm release:canary --tag "$RELEASE_TAG"
+
+  notify:
+    name: Send Discord Notification
+    needs: [release]
+    if: needs.release.outputs.staged == 'true'
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - name: Send a discord notification
+        # Skips cleanly when DISCORD_WEBHOOK_URL is not configured.
+        if: ${{ secrets.DISCORD_WEBHOOK_URL != '' }}
+        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            fetch(process.env.DISCORD_WEBHOOK_URL, {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({
+                content: `A new release is available 🎉. \n [Read the changelog](https://github.com/${context.repo.owner}/${context.repo.repo}/releases)`,
+              }),
+            })
+              .then((res) => {
+                console.log('Sent discord notification', res.status);
+              })
+              .catch((err) => {
+                console.error('Error sending discord notification', err);
+              });

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "lint:spell": "cspell \"**/*.{ts,md}\" --config ./cspell.json --no-progress",
     "release": "changeset publish",
     "release:canary": "changeset publish --no-git-tag",
-    "release:stage": "turbo run release:stage --filter=./packages/* --concurrency=1 --",
+    "release:stage": "turbo run release:stage --filter=./packages/* --continue --concurrency=1 --",
     "start": "turbo run start --filter=./packages/* --filter=./internals/*",
     "test": "vitest run --config ./configs/vitest.config.ts",
     "test:bench": "NODE_OPTIONS='--max_old_space_size=4096' vitest bench --config ./configs/vitest.bench.config.ts",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "release": "changeset publish",
     "release:canary": "changeset publish --no-git-tag",
     "release:stage": "turbo run release:stage --filter=./packages/* --continue --concurrency=1 --",
+    "release:stage:ci": "pnpm release:stage && pnpm exec changeset tag && echo \"staged=true\" >> \"${GITHUB_OUTPUT:-/dev/null}\"",
     "start": "turbo run start --filter=./packages/* --filter=./internals/*",
     "test": "vitest run --config ./configs/vitest.config.ts",
     "test:bench": "NODE_OPTIONS='--max_old_space_size=4096' vitest bench --config ./configs/vitest.bench.config.ts",

--- a/turbo.json
+++ b/turbo.json
@@ -53,7 +53,15 @@
     "release:stage": {
       "dependsOn": ["build"],
       "outputs": [],
-      "cache": false
+      "cache": false,
+      "passThroughEnv": [
+        "ACTIONS_ID_TOKEN_REQUEST_URL",
+        "ACTIONS_ID_TOKEN_REQUEST_TOKEN",
+        "NPM_CONFIG_PROVENANCE",
+        "GITHUB_*",
+        "RUNNER_*",
+        "SIGSTORE_*"
+      ]
     }
   }
 }


### PR DESCRIPTION
## Summary

Two related changes to the release pipeline:

### 1. `release:stage` continues on failure
Adds turbo's `--continue` flag so the release stage runs through every package even if one fails, instead of stopping after the first failure.

```diff
- "release:stage": "turbo run release:stage --filter=./packages/* --concurrency=1 --",
+ "release:stage": "turbo run release:stage --filter=./packages/* --continue --concurrency=1 --",
```

### 2. Align the release flow with the `kubb` repo
Brings the staged-publish mechanism in line with `kubb-labs/kubb`, keeping template-specific bits (`repository_owner`, local `./.github/setup`):

- **`release:stage:ci` script** — chains `release:stage` → `changeset tag` → emits the `staged` output the workflow gates on.
- **turbo `passThroughEnv`** on `release:stage` — forwards OIDC / provenance env (`ACTIONS_ID_TOKEN_*`, `NPM_CONFIG_PROVENANCE`, `GITHUB_*`, `RUNNER_*`, `SIGSTORE_*`) into the task.
- **Release hardening** — `pnpm install --frozen-lockfile --force` before build so the release doesn't trust a cache-restored pnpm store.
- **Workflow staging flow** — `publish: pnpm release:stage:ci`, `staged != 'true'` gate, canary uses `release:canary`.
- **Discord notification job** — generic version that links to this repo's GitHub releases (no kubb.dev links) and skips cleanly when `DISCORD_WEBHOOK_URL` isn't configured.

https://claude.ai/code/session_01P7JfZwRUDKrAZAv5XQVnY9