### PR TITLE
ci: release workflow — version PR fix, changeset CLI direct, canary snapshot on push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ on:
     paths:
       - '.changeset/**'
       - 'packages/**'
+      - '.github/workflows/release.yml'
 
 permissions: {}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,12 +51,44 @@ jobs:
         id: changesets
         uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b # v1
         with:
-          version: pnpm run version
+          version: pnpm exec changeset version
           commit: 'ci(changesets): version packages'
           title: 'ci(changesets): version packages'
           setupGitUser: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  canary:
+    name: Publish canary
+    if: github.repository_owner == 'stijnvanhulle' && (github.event_name == 'push' || github.event.inputs.tag != '')
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Check out code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup Tools
+        uses: ./.github/setup
+        with:
+          node-version: '22'
+          cache: 'false'
+
+      - name: Build
+        run: pnpm run build
+
+      - name: Publish canary snapshot
+        env:
+          NPM_CONFIG_PROVENANCE: true
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CANARY_TAG: ${{ github.event.inputs.tag || 'canary' }}
+        run: |
+          pnpm exec changeset version --snapshot "$CANARY_TAG"
+          pnpm exec changeset publish --no-git-tag --tag "$CANARY_TAG"
 
   release:
     name: Release
@@ -64,9 +96,8 @@ jobs:
     if: |
       always() &&
       github.repository_owner == 'stijnvanhulle' &&
-      (github.event.inputs.tag != '' ||
-        ((github.event_name != 'workflow_dispatch' || github.event.inputs.mode != 'version') &&
-          needs.version.result == 'success' && needs.version.outputs.hasChangesets == 'false'))
+      (github.event_name != 'workflow_dispatch' || github.event.inputs.mode != 'version') &&
+      needs.version.result == 'success' && needs.version.outputs.hasChangesets == 'false'
     timeout-minutes: 15
     runs-on: ubuntu-latest
     permissions:
@@ -98,25 +129,12 @@ jobs:
       - name: Publish
         id: changesets
         uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b # v1
-        if: ${{ github.event.inputs.tag == '' }}
         with:
           publish: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.mode == 'publish') && 'pnpm release' || 'pnpm release:stage:ci' }}
           setupGitUser: false
         env:
           NPM_CONFIG_PROVENANCE: true
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Publish ${{ inputs.tag || 'canary' }}
-        id: canary
-        if: ${{ github.event.inputs.tag != '' }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_CONFIG_PROVENANCE: true
-          RELEASE_TAG: ${{ inputs.tag || 'canary' }}
-        run: |
-          git checkout main
-          pnpm version:canary
-          pnpm release:canary --tag "$RELEASE_TAG"
 
   notify:
     name: Send Discord Notification

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
         id: changesets
         uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b # v1
         with:
-          version: pnpm version
+          version: pnpm run version
           commit: 'ci(changesets): version packages'
           title: 'ci(changesets): version packages'
           setupGitUser: false

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "lint:fix": "oxlint -c oxlint.config.ts --fix ./packages",
     "lint:spell": "cspell \"**/*.{ts,md}\" --config ./cspell.json --no-progress",
     "release": "changeset publish",
-    "release:canary": "changeset publish --no-git-tag",
     "release:stage": "turbo run release:stage --filter=./packages/* --continue --concurrency=1 --",
     "release:stage:ci": "pnpm release:stage && pnpm exec changeset tag && echo \"staged=true\" >> \"${GITHUB_OUTPUT:-/dev/null}\"",
     "start": "turbo run start --filter=./packages/* --filter=./internals/*",
@@ -34,9 +33,7 @@
     "test:bench": "NODE_OPTIONS='--max_old_space_size=4096' vitest bench --config ./configs/vitest.bench.config.ts",
     "test:watch": "vitest --config ./configs/vitest.config.ts",
     "typecheck": "turbo run typecheck --continue --filter='./packages/*' --filter='./internals/*'",
-    "upgrade": "npx taze -r -w --exclude pnpm --maturity-period 3",
-    "version": "changeset version",
-    "version:canary": "changeset version --snapshot canary"
+    "upgrade": "npx taze -r -w --exclude pnpm --maturity-period 3"
   },
   "devDependencies": {
     "@changesets/changelog-github": "^0.6.0",


### PR DESCRIPTION
## Changes

**1. Open the Version Packages PR reliably.** The `version` job now runs the changeset CLI directly (`version: pnpm exec changeset version`) instead of the `package.json` `version` script. `pnpm version` is a reserved built-in (it printed the version table and never ran `changeset version`), so no Version Packages PR was produced. `pnpm exec` is used so the local `changeset` binary resolves on PATH.

**2. Re-trigger on workflow edits.** Added `.github/workflows/release.yml` to `on.push.paths` so editing the release workflow re-runs it (closes the trigger gap that hid this).

**3. Canary snapshot on every push.** New dedicated `canary` job: on every push to a release branch (and on a `tag` dispatch) it publishes a changesets snapshot via `pnpm exec changeset version --snapshot <tag>` + `changeset publish --no-git-tag --tag <tag>` (default tag `canary`). Never lands on `latest`. With no pending changesets it's a no-op (snapshots are built from queued changesets).

**4. Dropped unused npm scripts.** Removed `version`, `version:canary`, and `release:canary` from `package.json` — the workflow calls the changeset CLI directly now. (`release`, `release:stage`, `release:stage:ci` kept.)

## Mode/trigger matrix

| Trigger | version | canary | release |
| --- | --- | --- | --- |
| push, changesets queued | opens PR | publishes snapshot | skipped |
| push, no changesets | no-op | no-op | staged publish |
| dispatch `version` | opens PR | – | – |
| dispatch `staged`/`publish` | no-op | – | stage / publish to latest |
| dispatch with `tag` | – | snapshot under `<tag>` | – |
