### PR TITLE
docs: align pre-PR check sequence and add tool-agnostic spec-driven guidance

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,7 +5,7 @@
 ## ✅ Checklist
 
 - [ ] I have followed the steps in the [Contributing guide](../blob/main/CONTRIBUTING.md).
-- [ ] I have tested this code locally with `pnpm run test`.
+- [ ] I ran the full pre-PR check locally: `pnpm format && pnpm lint:fix && pnpm typecheck && pnpm test`.
 
 ## 🚀 Release Impact
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,8 +34,22 @@ The full folder structure, repository setup, and commands live in
 ## Commits and PRs
 
 Use [Conventional Commits](https://www.conventionalcommits.org/). Before a PR, run
-`pnpm format && pnpm lint && pnpm typecheck && pnpm test`, and add a changeset
-(`pnpm changeset`) for any published-package change.
+`pnpm format && pnpm lint:fix && pnpm typecheck && pnpm test`, and add a changeset
+(`pnpm changeset`) for any published-package change. The same command sequence is
+what the PR template asks contributors to confirm.
+
+## Resuming work
+
+When picking up an in-progress task, before editing anything:
+
+1. `git status` and `git log -10 --oneline` to see the working tree and recent history.
+2. Check `plans/` for an active feature folder. If one exists, read its `spec.md`,
+   the latest unchecked slice (`NNN-<slug>.md`), and `verification.md` to find the
+   next step.
+3. Run `pnpm install`, then the same pre-PR sequence above to confirm the baseline
+   is green before changing code.
+4. Leave a short note in the relevant slice or `verification.md` before ending the
+   session so the next agent knows where you stopped.
 
 ## Token optimized CLI (rtk)
 

--- a/cspell.json
+++ b/cspell.json
@@ -44,6 +44,7 @@
     "frontmatter",
     "licence",
     "nominalizations",
+    "oneline",
     "rebranded",
     "scannability",
     "twoslash",

--- a/plans/README.md
+++ b/plans/README.md
@@ -38,12 +38,29 @@ plans/
 
 ## How to use it
 
-1. `/spec <feature>` creates `plans/<feature>/spec.md`.
-2. `/plan <feature>` turns the spec and research into `plan.md` and scaffolds the slice files.
-3. `/implement <feature>` works each `NNN-<slug>.md` slice in order, ticking its Done criteria as the slice passes.
-4. `/verify <feature>` fills and runs `verification.md`.
+Claude Code users have slash-command shortcuts; every other agent runs the same workflow by
+copying the template files by hand.
+
+| Phase | Claude Code | Any other agent |
+| --- | --- | --- |
+| Specify | `/spec <feature>` | `cp plans/templates/spec.md plans/<feature>/spec.md` and fill it in |
+| Research | (manual) | `cp plans/templates/research.md plans/<feature>/research.md` and fill it in |
+| Plan | `/plan <feature>` | `cp plans/templates/plan.md plans/<feature>/plan.md`, then `cp plans/templates/slice.md plans/<feature>/NNN-<slug>.md` per slice |
+| Execute | `/implement <feature>` | Open the lowest-numbered unchecked slice, follow its Steps, tick its Done criteria as Verification passes |
+| Verify | `/verify <feature>` | `cp plans/templates/verification.md plans/<feature>/verification.md`, then run each scenario |
 
 The `spec-driven` skill explains the same flow and when to reach for it.
+
+## Resuming an in-progress feature
+
+Picking up someone else's plan:
+
+1. `ls plans/` to find the active feature folder (the one with unchecked Done criteria).
+2. Read `spec.md` for intent, then `plan.md` for the slice list.
+3. Open the lowest-numbered `NNN-<slug>.md` slice that still has unchecked Done items.
+4. Run that slice's Verification first to confirm the current state before changing anything.
+5. When ending the session, leave a short note in the slice or `verification.md` so the next
+   agent knows where you stopped.
 
 ## Credit
 

--- a/plans/README.md
+++ b/plans/README.md
@@ -38,7 +38,7 @@ plans/
 
 ## How to use it
 
-Claude Code users have slash-command shortcuts; every other agent runs the same workflow by
+Claude Code users have slash-command shortcuts. Every other agent runs the same workflow by
 copying the template files by hand.
 
 | Phase | Claude Code | Any other agent |

--- a/tools/claude/skills/pr/SKILL.md
+++ b/tools/claude/skills/pr/SKILL.md
@@ -14,21 +14,22 @@ This skill instructs agents on PR preconditions, changeset usage, and reviewer e
 
 ## What It Does
 
-- Enforces the PR checklist: `format, lint, typecheck, tests`
+- Enforces the PR checklist: `format, lint:fix, typecheck, test`
 - Instructs on creating and using changesets for version bumps
 - Describes release/merge expectations and documentation updates
 
 ## Commands to Suggest
 
+The same sequence is named in `AGENTS.md`, `CONTRIBUTING.md`, and the PR template:
+
 ```bash
-pnpm format && pnpm lint:fix
-pnpm typecheck
-pnpm test
-pnpm changeset
+pnpm format && pnpm lint:fix && pnpm typecheck && pnpm test
+pnpm changeset   # only when a published package changed
 ```
 
 ## Checklist
 
+- [ ] Local pre-PR sequence above passes
 - [ ] CI green (unit tests, linters, typechecks)
 - [ ] Documentation updated if public behavior changed
 - [ ] No secrets in the PR

--- a/tools/claude/skills/spec-driven/SKILL.md
+++ b/tools/claude/skills/spec-driven/SKILL.md
@@ -6,24 +6,37 @@ description: "Drive a spec-driven workflow for a larger feature: specify require
 # Spec-driven development
 
 A structured workflow for features big enough to warrant a paper trail. Each feature gets its
-own folder `plans/<feature>/`. Blank templates live in `plans/templates/`, and the `/spec`,
-`/plan`, and `/verify` commands copy them in. For small, obvious changes, use the lightweight
-`plan` output style instead (a single inline plan, no files).
+own folder `plans/<feature>/`. Blank templates live in `plans/templates/`. For small, obvious
+changes, use the lightweight `plan` output style instead (a single inline plan, no files).
+
+Claude Code users have slash-command shortcuts (`/spec`, `/plan`, `/implement`, `/verify`) that
+copy the right template into place. Every other agent runs the same workflow by copying the
+template file by hand. The phases below give both forms.
 
 ## Phases
 
 1. **Specify** (`plans/<feature>/spec.md`): capture requirements (`FR-N`) and acceptance
-   criteria (`AC-N`). Describe behavior and outcomes, not code. Run `/spec <feature>`.
+   criteria (`AC-N`). Describe behavior and outcomes, not code.
+   - Claude: `/spec <feature>`.
+   - Other agents: `cp plans/templates/spec.md plans/<feature>/spec.md`, then fill it in.
 2. **Research** (`plans/<feature>/research.md`): record decisions with their reasoning, open
    questions, and operating constraints.
+   - All agents: `cp plans/templates/research.md plans/<feature>/research.md`, then fill it in.
 3. **Plan** (`plans/<feature>/plan.md`): the architecture and a breakdown into numbered slices,
-   each demonstrable on its own. Run `/plan <feature>`. Scaffold each slice from
-   `plans/templates/slice.md` into `plans/<feature>/NNN-<slug>.md`.
+   each demonstrable on its own.
+   - Claude: `/plan <feature>`.
+   - Other agents: `cp plans/templates/plan.md plans/<feature>/plan.md`, then for each slice
+     copy `plans/templates/slice.md` to `plans/<feature>/NNN-<slug>.md`.
 4. **Execute** (`plans/<feature>/NNN-<slug>.md`): implement one slice at a time, ticking each
-   slice's Done criteria as its verification passes, and keep each slice runnable. Run
-   `/implement <feature>`.
+   slice's Done criteria as its verification passes, and keep each slice runnable.
+   - Claude: `/implement <feature>`.
+   - Other agents: open the lowest-numbered unchecked slice, follow its Steps, run its
+     Verification, then tick its Done criteria.
 5. **Verify** (`plans/<feature>/verification.md`): walk end-to-end scenarios, each mapped back
-   to an `AC-N`. Run `/verify <feature>`.
+   to an `AC-N`.
+   - Claude: `/verify <feature>`.
+   - Other agents: `cp plans/templates/verification.md plans/<feature>/verification.md`,
+     write one scenario per `AC-N`, then run them against the live app.
 
 ## Rules
 
@@ -31,3 +44,13 @@ own folder `plans/<feature>/`. Blank templates live in `plans/templates/`, and t
 - Every acceptance criterion (`AC-N`) must have a matching verification scenario.
 - Keep slices small and independently demonstrable, one concern each.
 - See `plans/README.md` for the file roles and the per-feature layout.
+
+## Resuming an in-progress feature
+
+1. `ls plans/` to find the active feature folder (the one with unchecked Done criteria).
+2. Read `spec.md` for intent, then `plan.md` for the slice list.
+3. Open the lowest-numbered `NNN-<slug>.md` slice that still has unchecked Done items.
+4. Run that slice's Verification commands first, to confirm where the previous agent stopped,
+   before changing anything.
+5. When you end the session, leave a short note in the slice or `verification.md` so the next
+   agent knows the current state.


### PR DESCRIPTION
## Summary

Addresses the AI agent readiness audit feedback for repositories built on this template. The same drift the audit flagged in the downstream fork is fixed at the source so future forks inherit the alignment.

- **Aligned the pre-PR check sequence** across `AGENTS.md`, `CONTRIBUTING.md`, the PR template, and the `pr` skill. All four now name the same `pnpm format && pnpm lint:fix && pnpm typecheck && pnpm test` command, instead of the PR template asking only for `pnpm run test`.
- **Mirrored the Claude slash-command workflow in tool-agnostic guidance.** The `spec-driven` skill and `plans/README.md` now show the file-copy equivalent of `/spec`, `/plan`, `/implement`, and `/verify`, so non-Claude agents can run the same workflow without hitting a Claude-only path.
- **Added a compact resume checklist** in `AGENTS.md` and `plans/README.md`, so an agent picking up an in-progress feature has a short, ordered set of steps: inspect git status, find the active plan folder, open the lowest-numbered unchecked slice, re-run its Verification before changing anything, and leave a closing note for the next agent.

## Test plan

- [ ] Read `AGENTS.md`, `CONTRIBUTING.md`, and `.github/pull_request_template.md` side by side and confirm the pre-PR command is identical.
- [ ] Confirm a non-Claude agent could complete the spec-driven loop using only `plans/README.md` and the `spec-driven` skill.
- [ ] Confirm the new "Resuming work" sections in `AGENTS.md` and `plans/README.md` are reachable from the top-level headings.


---
_Generated by [Claude Code](https://claude.ai/code/session_019YFeDqAiwNgvxR89VqUCHS)_