### PR TITLE
docs: add shieldcn.dev badge group to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <div align="center">
 
-<a href="https://github.com/stijnvanhulle/template" target="_blank">
-  <img alt="stijnvanhulle/template badges" src="https://shieldcn.dev/group/github/stars/stijnvanhulle/template+badge/license-MIT-blue+badge/sponsors-stijnvanhulle-EA4AAA.svg?variant=branded&size=xs&theme=zinc&mode=dark">
-</a>
+[![Stars][stars-src]][stars-href]
+[![License][license-src]][license-href]
+[![Sponsors][sponsors-src]][sponsors-href]
 
   <h4>
     <a href="https://github.com/stijnvanhulle/template/issues/">Report Bug</a>
@@ -165,3 +165,12 @@ See [CONTRIBUTING.md](./CONTRIBUTING.md) for the project structure, prerequisite
 ## License
 
 [MIT](./LICENSE) © Stijn Van Hulle
+
+<!-- Badges -->
+
+[stars-src]: https://shieldcn.dev/github/stars/stijnvanhulle/template.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[stars-href]: https://github.com/stijnvanhulle/template
+[license-src]: https://shieldcn.dev/badge/license-MIT-blue.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[license-href]: https://github.com/stijnvanhulle/template/blob/main/LICENSE
+[sponsors-src]: https://shieldcn.dev/badge/sponsors-stijnvanhulle-EA4AAA.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[sponsors-href]: https://github.com/sponsors/stijnvanhulle

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 <div align="center">
 
+<a href="https://github.com/stijnvanhulle/template" target="_blank">
+  <img alt="stijnvanhulle/template badges" src="https://shieldcn.dev/group/github/stars/stijnvanhulle/template+github/license/stijnvanhulle/template+github/sponsors/stijnvanhulle.svg?variant=branded&size=xs&theme=zinc&mode=dark">
+</a>
+
   <h4>
     <a href="https://github.com/stijnvanhulle/template/issues/">Report Bug</a>
     <span> · </span>

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Stars][stars-src]][stars-href]
 [![License][license-src]][license-href]
+[![Coverage][coverage-src]][coverage-href]
 
   <h4>
     <a href="https://github.com/stijnvanhulle/template/issues/">Report Bug</a>
@@ -171,3 +172,5 @@ See [CONTRIBUTING.md](./CONTRIBUTING.md) for the project structure, prerequisite
 [stars-href]: https://github.com/stijnvanhulle/template
 [license-src]: https://shieldcn.dev/badge/license-MIT-blue.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [license-href]: https://github.com/stijnvanhulle/template/blob/main/LICENSE
+[coverage-src]: https://shieldcn.dev/codecov/github/stijnvanhulle/template.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[coverage-href]: https://app.codecov.io/gh/stijnvanhulle/template

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ See [CONTRIBUTING.md](./CONTRIBUTING.md) for the project structure, prerequisite
 
 [stars-src]: https://shieldcn.dev/github/stars/stijnvanhulle/template.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/stijnvanhulle/template
-[license-src]: https://shieldcn.dev/badge/license-MIT-blue.svg?variant=secondary&size=xs&theme=zinc
+[license-src]: https://shieldcn.dev/npm/license/@stijnvanhulle/template-core.svg?variant=secondary&size=xs&theme=zinc
 [license-href]: https://github.com/stijnvanhulle/template/blob/main/LICENSE
 [coverage-src]: https://shieldcn.dev/codecov/github/stijnvanhulle/template.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [coverage-href]: https://app.codecov.io/gh/stijnvanhulle/template

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![Stars][stars-src]][stars-href]
 [![License][license-src]][license-href]
-[![Sponsors][sponsors-src]][sponsors-href]
 
   <h4>
     <a href="https://github.com/stijnvanhulle/template/issues/">Report Bug</a>
@@ -172,5 +171,3 @@ See [CONTRIBUTING.md](./CONTRIBUTING.md) for the project structure, prerequisite
 [stars-href]: https://github.com/stijnvanhulle/template
 [license-src]: https://shieldcn.dev/badge/license-MIT-blue.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [license-href]: https://github.com/stijnvanhulle/template/blob/main/LICENSE
-[sponsors-src]: https://shieldcn.dev/badge/sponsors-stijnvanhulle-EA4AAA.svg?variant=branded&size=xs&theme=zinc&mode=dark
-[sponsors-href]: https://github.com/sponsors/stijnvanhulle

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <div align="center">
 
 <a href="https://github.com/stijnvanhulle/template" target="_blank">
-  <img alt="stijnvanhulle/template badges" src="https://shieldcn.dev/group/github/stars/stijnvanhulle/template+github/license/stijnvanhulle/template+github/sponsors/stijnvanhulle.svg?variant=branded&size=xs&theme=zinc&mode=dark">
+  <img alt="stijnvanhulle/template badges" src="https://shieldcn.dev/group/github/stars/stijnvanhulle/template+badge/license-MIT-blue+badge/sponsors-stijnvanhulle-EA4AAA.svg?variant=branded&size=xs&theme=zinc&mode=dark">
 </a>
 
   <h4>

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ See [CONTRIBUTING.md](./CONTRIBUTING.md) for the project structure, prerequisite
 
 [stars-src]: https://shieldcn.dev/github/stars/stijnvanhulle/template.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/stijnvanhulle/template
-[license-src]: https://shieldcn.dev/badge/license-MIT-blue.svg?variant=secondary&size=xs&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/badge/license-MIT-blue.svg?variant=secondary&size=xs&theme=zinc
 [license-href]: https://github.com/stijnvanhulle/template/blob/main/LICENSE
 [coverage-src]: https://shieldcn.dev/codecov/github/stijnvanhulle/template.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [coverage-href]: https://app.codecov.io/gh/stijnvanhulle/template

--- a/README.md
+++ b/README.md
@@ -168,9 +168,9 @@ See [CONTRIBUTING.md](./CONTRIBUTING.md) for the project structure, prerequisite
 
 <!-- Badges -->
 
-[stars-src]: https://shieldcn.dev/github/stars/stijnvanhulle/template.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[stars-src]: https://shieldcn.dev/github/stars/stijnvanhulle/template.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [stars-href]: https://github.com/stijnvanhulle/template
-[license-src]: https://shieldcn.dev/badge/license-MIT-blue.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/badge/license-MIT-blue.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [license-href]: https://github.com/stijnvanhulle/template/blob/main/LICENSE
-[coverage-src]: https://shieldcn.dev/codecov/github/stijnvanhulle/template.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[coverage-src]: https://shieldcn.dev/codecov/github/stijnvanhulle/template.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [coverage-href]: https://app.codecov.io/gh/stijnvanhulle/template

--- a/README.md
+++ b/README.md
@@ -168,9 +168,9 @@ See [CONTRIBUTING.md](./CONTRIBUTING.md) for the project structure, prerequisite
 
 <!-- Badges -->
 
-[stars-src]: https://shieldcn.dev/github/stars/stijnvanhulle/template.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[stars-src]: https://shieldcn.dev/github/stars/stijnvanhulle/template.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/stijnvanhulle/template
-[license-src]: https://shieldcn.dev/badge/license-MIT-blue.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/badge/license-MIT-blue.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [license-href]: https://github.com/stijnvanhulle/template/blob/main/LICENSE
-[coverage-src]: https://shieldcn.dev/codecov/github/stijnvanhulle/template.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[coverage-src]: https://shieldcn.dev/codecov/github/stijnvanhulle/template.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [coverage-href]: https://app.codecov.io/gh/stijnvanhulle/template

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -12,13 +12,13 @@
 
 <!-- Badges -->
 
-[npm-version-src]: https://shieldcn.dev/npm/v/@stijnvanhulle/template-core.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[npm-version-src]: https://shieldcn.dev/npm/v/@stijnvanhulle/template-core.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [npm-version-href]: https://npmx.dev/package/@stijnvanhulle/template-core
-[npm-downloads-src]: https://shieldcn.dev/npm/dm/@stijnvanhulle/template-core.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[npm-downloads-src]: https://shieldcn.dev/npm/dm/@stijnvanhulle/template-core.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [npm-downloads-href]: https://npmx.dev/package/@stijnvanhulle/template-core
-[stars-src]: https://shieldcn.dev/github/stars/stijnvanhulle/template.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[stars-src]: https://shieldcn.dev/github/stars/stijnvanhulle/template.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [stars-href]: https://github.com/stijnvanhulle/template
-[license-src]: https://shieldcn.dev/npm/license/@stijnvanhulle/template-core.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@stijnvanhulle/template-core.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [license-href]: https://github.com/stijnvanhulle/template/blob/main/LICENSE
-[node-src]: https://shieldcn.dev/npm/node/@stijnvanhulle/template-core.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[node-src]: https://shieldcn.dev/npm/node/@stijnvanhulle/template-core.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [node-href]: https://npmx.dev/package/@stijnvanhulle/template-core

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -13,12 +13,12 @@
 <!-- Badges -->
 
 [npm-version-src]: https://shieldcn.dev/npm/v/@stijnvanhulle/template-core.svg?variant=branded&size=xs&theme=zinc&mode=dark
-[npm-version-href]: https://npmjs.com/package/@stijnvanhulle/template-core
+[npm-version-href]: https://npmx.dev/package/@stijnvanhulle/template-core
 [npm-downloads-src]: https://shieldcn.dev/npm/dm/@stijnvanhulle/template-core.svg?variant=branded&size=xs&theme=zinc&mode=dark
-[npm-downloads-href]: https://npmjs.com/package/@stijnvanhulle/template-core
+[npm-downloads-href]: https://npmx.dev/package/@stijnvanhulle/template-core
 [stars-src]: https://shieldcn.dev/github/stars/stijnvanhulle/template.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/stijnvanhulle/template
 [license-src]: https://shieldcn.dev/npm/license/@stijnvanhulle/template-core.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [license-href]: https://github.com/stijnvanhulle/template/blob/main/LICENSE
 [node-src]: https://shieldcn.dev/npm/node/@stijnvanhulle/template-core.svg?variant=branded&size=xs&theme=zinc&mode=dark
-[node-href]: https://npmjs.com/package/@stijnvanhulle/template-core
+[node-href]: https://npmx.dev/package/@stijnvanhulle/template-core

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -18,7 +18,7 @@
 [npm-downloads-href]: https://npmx.dev/package/@stijnvanhulle/template-core
 [stars-src]: https://shieldcn.dev/github/stars/stijnvanhulle/template.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/stijnvanhulle/template
-[license-src]: https://shieldcn.dev/npm/license/@stijnvanhulle/template-core.svg?variant=secondary&size=xs&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@stijnvanhulle/template-core.svg?variant=secondary&size=xs&theme=zinc
 [license-href]: https://github.com/stijnvanhulle/template/blob/main/LICENSE
 [node-src]: https://shieldcn.dev/npm/node/@stijnvanhulle/template-core.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [node-href]: https://npmx.dev/package/@stijnvanhulle/template-core

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -12,13 +12,13 @@
 
 <!-- Badges -->
 
-[npm-version-src]: https://shieldcn.dev/npm/v/@stijnvanhulle/template-core.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[npm-version-src]: https://shieldcn.dev/npm/v/@stijnvanhulle/template-core.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [npm-version-href]: https://npmx.dev/package/@stijnvanhulle/template-core
-[npm-downloads-src]: https://shieldcn.dev/npm/dm/@stijnvanhulle/template-core.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[npm-downloads-src]: https://shieldcn.dev/npm/dm/@stijnvanhulle/template-core.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [npm-downloads-href]: https://npmx.dev/package/@stijnvanhulle/template-core
-[stars-src]: https://shieldcn.dev/github/stars/stijnvanhulle/template.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[stars-src]: https://shieldcn.dev/github/stars/stijnvanhulle/template.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/stijnvanhulle/template
-[license-src]: https://shieldcn.dev/npm/license/@stijnvanhulle/template-core.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@stijnvanhulle/template-core.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [license-href]: https://github.com/stijnvanhulle/template/blob/main/LICENSE
-[node-src]: https://shieldcn.dev/npm/node/@stijnvanhulle/template-core.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[node-src]: https://shieldcn.dev/npm/node/@stijnvanhulle/template-core.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [node-href]: https://npmx.dev/package/@stijnvanhulle/template-core

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,1 +1,24 @@
+<div align="center">
+
+[![npm version][npm-version-src]][npm-version-href]
+[![npm downloads][npm-downloads-src]][npm-downloads-href]
+[![Stars][stars-src]][stars-href]
+[![License][license-src]][license-href]
+[![Node][node-src]][node-href]
+
+</div>
+
 # Core
+
+<!-- Badges -->
+
+[npm-version-src]: https://shieldcn.dev/npm/v/@stijnvanhulle/template-core.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[npm-version-href]: https://npmjs.com/package/@stijnvanhulle/template-core
+[npm-downloads-src]: https://shieldcn.dev/npm/dm/@stijnvanhulle/template-core.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[npm-downloads-href]: https://npmjs.com/package/@stijnvanhulle/template-core
+[stars-src]: https://shieldcn.dev/github/stars/stijnvanhulle/template.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[stars-href]: https://github.com/stijnvanhulle/template
+[license-src]: https://shieldcn.dev/npm/license/@stijnvanhulle/template-core.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[license-href]: https://github.com/stijnvanhulle/template/blob/main/LICENSE
+[node-src]: https://shieldcn.dev/npm/node/@stijnvanhulle/template-core.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[node-href]: https://npmjs.com/package/@stijnvanhulle/template-core

--- a/packages/demo/README.md
+++ b/packages/demo/README.md
@@ -18,7 +18,7 @@
 [npm-downloads-href]: https://npmx.dev/package/@stijnvanhulle/template-demo
 [stars-src]: https://shieldcn.dev/github/stars/stijnvanhulle/template.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/stijnvanhulle/template
-[license-src]: https://shieldcn.dev/npm/license/@stijnvanhulle/template-demo.svg?variant=secondary&size=xs&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@stijnvanhulle/template-demo.svg?variant=secondary&size=xs&theme=zinc
 [license-href]: https://github.com/stijnvanhulle/template/blob/main/LICENSE
 [node-src]: https://shieldcn.dev/npm/node/@stijnvanhulle/template-demo.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [node-href]: https://npmx.dev/package/@stijnvanhulle/template-demo

--- a/packages/demo/README.md
+++ b/packages/demo/README.md
@@ -1,1 +1,24 @@
+<div align="center">
+
+[![npm version][npm-version-src]][npm-version-href]
+[![npm downloads][npm-downloads-src]][npm-downloads-href]
+[![Stars][stars-src]][stars-href]
+[![License][license-src]][license-href]
+[![Node][node-src]][node-href]
+
+</div>
+
 # Demo
+
+<!-- Badges -->
+
+[npm-version-src]: https://shieldcn.dev/npm/v/@stijnvanhulle/template-demo.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[npm-version-href]: https://npmjs.com/package/@stijnvanhulle/template-demo
+[npm-downloads-src]: https://shieldcn.dev/npm/dm/@stijnvanhulle/template-demo.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[npm-downloads-href]: https://npmjs.com/package/@stijnvanhulle/template-demo
+[stars-src]: https://shieldcn.dev/github/stars/stijnvanhulle/template.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[stars-href]: https://github.com/stijnvanhulle/template
+[license-src]: https://shieldcn.dev/npm/license/@stijnvanhulle/template-demo.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[license-href]: https://github.com/stijnvanhulle/template/blob/main/LICENSE
+[node-src]: https://shieldcn.dev/npm/node/@stijnvanhulle/template-demo.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[node-href]: https://npmjs.com/package/@stijnvanhulle/template-demo

--- a/packages/demo/README.md
+++ b/packages/demo/README.md
@@ -12,13 +12,13 @@
 
 <!-- Badges -->
 
-[npm-version-src]: https://shieldcn.dev/npm/v/@stijnvanhulle/template-demo.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[npm-version-src]: https://shieldcn.dev/npm/v/@stijnvanhulle/template-demo.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [npm-version-href]: https://npmx.dev/package/@stijnvanhulle/template-demo
-[npm-downloads-src]: https://shieldcn.dev/npm/dm/@stijnvanhulle/template-demo.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[npm-downloads-src]: https://shieldcn.dev/npm/dm/@stijnvanhulle/template-demo.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [npm-downloads-href]: https://npmx.dev/package/@stijnvanhulle/template-demo
-[stars-src]: https://shieldcn.dev/github/stars/stijnvanhulle/template.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[stars-src]: https://shieldcn.dev/github/stars/stijnvanhulle/template.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/stijnvanhulle/template
-[license-src]: https://shieldcn.dev/npm/license/@stijnvanhulle/template-demo.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@stijnvanhulle/template-demo.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [license-href]: https://github.com/stijnvanhulle/template/blob/main/LICENSE
-[node-src]: https://shieldcn.dev/npm/node/@stijnvanhulle/template-demo.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[node-src]: https://shieldcn.dev/npm/node/@stijnvanhulle/template-demo.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [node-href]: https://npmx.dev/package/@stijnvanhulle/template-demo

--- a/packages/demo/README.md
+++ b/packages/demo/README.md
@@ -13,12 +13,12 @@
 <!-- Badges -->
 
 [npm-version-src]: https://shieldcn.dev/npm/v/@stijnvanhulle/template-demo.svg?variant=branded&size=xs&theme=zinc&mode=dark
-[npm-version-href]: https://npmjs.com/package/@stijnvanhulle/template-demo
+[npm-version-href]: https://npmx.dev/package/@stijnvanhulle/template-demo
 [npm-downloads-src]: https://shieldcn.dev/npm/dm/@stijnvanhulle/template-demo.svg?variant=branded&size=xs&theme=zinc&mode=dark
-[npm-downloads-href]: https://npmjs.com/package/@stijnvanhulle/template-demo
+[npm-downloads-href]: https://npmx.dev/package/@stijnvanhulle/template-demo
 [stars-src]: https://shieldcn.dev/github/stars/stijnvanhulle/template.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/stijnvanhulle/template
 [license-src]: https://shieldcn.dev/npm/license/@stijnvanhulle/template-demo.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [license-href]: https://github.com/stijnvanhulle/template/blob/main/LICENSE
 [node-src]: https://shieldcn.dev/npm/node/@stijnvanhulle/template-demo.svg?variant=branded&size=xs&theme=zinc&mode=dark
-[node-href]: https://npmjs.com/package/@stijnvanhulle/template-demo
+[node-href]: https://npmx.dev/package/@stijnvanhulle/template-demo

--- a/packages/demo/README.md
+++ b/packages/demo/README.md
@@ -12,13 +12,13 @@
 
 <!-- Badges -->
 
-[npm-version-src]: https://shieldcn.dev/npm/v/@stijnvanhulle/template-demo.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[npm-version-src]: https://shieldcn.dev/npm/v/@stijnvanhulle/template-demo.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [npm-version-href]: https://npmx.dev/package/@stijnvanhulle/template-demo
-[npm-downloads-src]: https://shieldcn.dev/npm/dm/@stijnvanhulle/template-demo.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[npm-downloads-src]: https://shieldcn.dev/npm/dm/@stijnvanhulle/template-demo.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [npm-downloads-href]: https://npmx.dev/package/@stijnvanhulle/template-demo
-[stars-src]: https://shieldcn.dev/github/stars/stijnvanhulle/template.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[stars-src]: https://shieldcn.dev/github/stars/stijnvanhulle/template.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [stars-href]: https://github.com/stijnvanhulle/template
-[license-src]: https://shieldcn.dev/npm/license/@stijnvanhulle/template-demo.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@stijnvanhulle/template-demo.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [license-href]: https://github.com/stijnvanhulle/template/blob/main/LICENSE
-[node-src]: https://shieldcn.dev/npm/node/@stijnvanhulle/template-demo.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[node-src]: https://shieldcn.dev/npm/node/@stijnvanhulle/template-demo.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [node-href]: https://npmx.dev/package/@stijnvanhulle/template-demo


### PR DESCRIPTION
## Summary

- Add a single shieldcn.dev badge group (stars + license + sponsors) at the top of the template README
- Use `variant=branded`, `size=xs`, `theme=zinc`, `mode=dark` to match the dark zinc look used across the other Kubb-org repos

## Test plan

- [ ] Open `README.md` on GitHub and confirm the badge group renders with the dark zinc theme
- [ ] Hit the group URL in a browser to confirm `shieldcn.dev` returns a 200 SVG

https://claude.ai/code/session_013waRRjU1q7UcNXb3Tnnvqa

---
_Generated by [Claude Code](https://claude.ai/code/session_013waRRjU1q7UcNXb3Tnnvqa)_