### PR TITLE
build(tsconfig): scope type lib to Node 22 features

### DIFF
--- a/configs/base.json
+++ b/configs/base.json
@@ -5,7 +5,16 @@
     /* Base Options: */
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "target": "ES2022",
+    "target": "ES2024",
+    /*
+     * Type lib scoped to what Node 22 (V8 12.4) actually ships, so the types
+     * match the runtime. ES2024 covers Object.groupBy / Map.groupBy and
+     * Promise.withResolvers. The ES2025 sublibs add Set methods (Collection)
+     * and iterator helpers (Iterator), and ESNext.Array adds Array.fromAsync.
+     * Granular sublibs are deliberate: the full ES2025 lib would also expose
+     * Float16Array, which is Node 24, not Node 22.
+     */
+    "lib": ["ES2024", "ES2025.Collection", "ES2025.Iterator", "ESNext.Array"],
     "verbatimModuleSyntax": true,
     "allowJs": true,
     "resolveJsonModule": true,

--- a/configs/base.json
+++ b/configs/base.json
@@ -6,14 +6,6 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "target": "ES2024",
-    /*
-     * Type lib scoped to what Node 22 (V8 12.4) actually ships, so the types
-     * match the runtime. ES2024 covers Object.groupBy / Map.groupBy and
-     * Promise.withResolvers. The ES2025 sublibs add Set methods (Collection)
-     * and iterator helpers (Iterator), and ESNext.Array adds Array.fromAsync.
-     * Granular sublibs are deliberate: the full ES2025 lib would also expose
-     * Float16Array, which is Node 24, not Node 22.
-     */
     "lib": ["ES2024", "ES2025.Collection", "ES2025.Iterator", "ESNext.Array"],
     "verbatimModuleSyntax": true,
     "allowJs": true,


### PR DESCRIPTION
## What

Bump `target` to `ES2024` and set an explicit `lib` in `configs/base.json` so the TypeScript type library matches what Node 22 (V8 12.4) ships at runtime.

```jsonc
"target": "ES2024",
"lib": ["ES2024", "ES2025.Collection", "ES2025.Iterator", "ESNext.Array"]
```

## Why

The project runs on Node 22 (CI and `engines` already pin it), but `target` was `ES2022` with no `lib`, so the type library stopped at ES2022. Node 22 language built-ins did not typecheck even though they run fine. As the linked DefinitelyTyped discussion notes, language built-ins come from TypeScript's `lib`, not `@types/node`.

Feature to lib mapping (TypeScript 6.0.3):

| Node 22 feature | lib |
| --- | --- |
| `toSorted` / `toReversed` / `with` | ES2023 (in ES2024) |
| `Object.groupBy` / `Map.groupBy`, `Promise.withResolvers` | ES2024 |
| Set methods (`union` / `intersection` / `difference` / …) | ES2025.Collection |
| Iterator helpers (`map` / `filter` / `take` / `toArray` / …) | ES2025.Iterator |
| `Array.fromAsync` | ESNext.Array |

## Only Node 22, nothing beyond

The granular sublibs are deliberate. The full `ES2025` lib would also pull in `Float16Array` (Node 24), and `ESNext.Collection` would pull in `Map.getOrInsert` (a Stage-3 proposal, not in Node 22). Both are excluded by this config. Verified:

- All six features above typecheck.
- `new Float16Array(2)` → `error TS2304: Cannot find name 'Float16Array'`.
- `new Map().getOrInsert("a", 1)` → `error TS2550: Property 'getOrInsert' does not exist`.

## Verify

```bash
pnpm typecheck && pnpm test
```

Both pass; `pnpm format` and `pnpm lint` are clean.

Ref: https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/74504

https://claude.ai/code/session_01PazNrvKYZSS5eYu9DUGurf

---
_Generated by [Claude Code](https://claude.ai/code/session_01PazNrvKYZSS5eYu9DUGurf)_