### PR TITLE
fix(plugin): add marketplace manifest so the documented install works

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-marketplace-manifest.json",
+  "name": "stijnvanhulle-template",
+  "owner": {
+    "name": "stijnvanhulle",
+    "url": "https://github.com/stijnvanhulle"
+  },
+  "metadata": {
+    "description": "Marketplace for the stijnvanhulle toolkit plugin."
+  },
+  "plugins": [
+    {
+      "name": "plugin",
+      "source": "./tools/claude",
+      "description": "Spec-driven workflow, writing-voice skills, code-reviewer agent, and shared TypeScript-monorepo conventions."
+    }
+  ]
+}

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-marketplace-manifest.json",
-  "name": "stijnvanhulle-template",
+  "name": "stijnvanhulle",
   "owner": {
     "name": "stijnvanhulle",
     "url": "https://github.com/stijnvanhulle"
@@ -10,7 +10,7 @@
   },
   "plugins": [
     {
-      "name": "plugin",
+      "name": "template",
       "source": "./tools/claude",
       "description": "Spec-driven workflow, writing-voice skills, code-reviewer agent, and shared TypeScript-monorepo conventions."
     }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,7 +80,7 @@ symlink to it so Claude Code, Gemini CLI, and GitHub Copilot pick up the
 same content. The shared toolset (skills, commands, code-reviewer agent,
 output styles, and conventions) lives in `tools/claude/`, which is also
 packaged as a Claude Code plugin (installable as
-`plugin@stijnvanhulle-template`). The `.claude/` and `.agents/skills/`
+`template@stijnvanhulle`). The `.claude/` and `.agents/skills/`
 paths used by the workspace symlink into that folder, so the template repo
 and any project that installs the plugin run the same content.
 Workspace-only pieces (hooks and `settings.json`) stay under `.claude/`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,7 +80,7 @@ symlink to it so Claude Code, Gemini CLI, and GitHub Copilot pick up the
 same content. The shared toolset (skills, commands, code-reviewer agent,
 output styles, and conventions) lives in `tools/claude/`, which is also
 packaged as a Claude Code plugin (installable as
-`plugin@stijnvanhulle/template`). The `.claude/` and `.agents/skills/`
+`plugin@stijnvanhulle-template`). The `.claude/` and `.agents/skills/`
 paths used by the workspace symlink into that folder, so the template repo
 and any project that installs the plugin run the same content.
 Workspace-only pieces (hooks and `settings.json`) stay under `.claude/`.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Agent Skills, and uses symlinks so every tool reads from one source instead of d
 
 `AGENTS.md` is the canonical instruction file. The shared toolset (skills, commands,
 code-reviewer agent, output styles, and conventions) lives in `tools/claude/`, which doubles as
-a Claude Code plugin (installable as `plugin@stijnvanhulle-template`). The workspace paths under `.claude/` and `.agents/`
+a Claude Code plugin (installable as `template@stijnvanhulle`). The workspace paths under `.claude/` and `.agents/`
 symlink into that folder, so the template repo and any project that installs the plugin run
 the same content from a single source of truth. See [tools/claude/README.md](tools/claude/README.md)
 for install steps.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Agent Skills, and uses symlinks so every tool reads from one source instead of d
 
 `AGENTS.md` is the canonical instruction file. The shared toolset (skills, commands,
 code-reviewer agent, output styles, and conventions) lives in `tools/claude/`, which doubles as
-a Claude Code plugin (installable as `plugin@stijnvanhulle/template`). The workspace paths under `.claude/` and `.agents/`
+a Claude Code plugin (installable as `plugin@stijnvanhulle-template`). The workspace paths under `.claude/` and `.agents/`
 symlink into that folder, so the template repo and any project that installs the plugin run
 the same content from a single source of truth. See [tools/claude/README.md](tools/claude/README.md)
 for install steps.

--- a/tools/claude/.claude-plugin/plugin.json
+++ b/tools/claude/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
-  "name": "plugin",
+  "name": "template",
   "displayName": "stijnvanhulle toolkit",
   "version": "0.1.0",
   "description": "Spec-driven workflow, writing-voice skills, code-reviewer agent, and shared TypeScript-monorepo conventions. Extracted from stijnvanhulle/template so other projects can install the same toolset.",

--- a/tools/claude/README.md
+++ b/tools/claude/README.md
@@ -6,8 +6,8 @@ the always-on rules (code style, JSDoc, markdown, security, testing).
 
 The toolkit is extracted from [stijnvanhulle/template](https://github.com/stijnvanhulle/template)
 so the same content powers the template repo itself and any project that installs
-the plugin. It is published under the plugin name `plugin` from the `stijnvanhulle-template` marketplace, so the install reads as
-`plugin@stijnvanhulle-template`.
+the plugin. It is published under the plugin name `template` from the `stijnvanhulle` marketplace, so the install reads as
+`template@stijnvanhulle`.
 
 ## What you get
 
@@ -39,7 +39,7 @@ spec-driven formatting (`plan`), and a diagrams-first layout (`diagrams-first`).
 ```bash
 # add this repo as a marketplace, then install the plugin
 /plugin marketplace add stijnvanhulle/template
-/plugin install plugin@stijnvanhulle-template
+/plugin install template@stijnvanhulle
 ```
 
 To try it locally before publishing:

--- a/tools/claude/README.md
+++ b/tools/claude/README.md
@@ -6,8 +6,8 @@ the always-on rules (code style, JSDoc, markdown, security, testing).
 
 The toolkit is extracted from [stijnvanhulle/template](https://github.com/stijnvanhulle/template)
 so the same content powers the template repo itself and any project that installs
-the plugin. It is published under the plugin name `plugin`, so the install reads as
-`plugin@stijnvanhulle/template`.
+the plugin. It is published under the plugin name `plugin` from the `stijnvanhulle-template` marketplace, so the install reads as
+`plugin@stijnvanhulle-template`.
 
 ## What you get
 
@@ -39,7 +39,7 @@ spec-driven formatting (`plan`), and a diagrams-first layout (`diagrams-first`).
 ```bash
 # add this repo as a marketplace, then install the plugin
 /plugin marketplace add stijnvanhulle/template
-/plugin install plugin@stijnvanhulle/template
+/plugin install plugin@stijnvanhulle-template
 ```
 
 To try it locally before publishing:


### PR DESCRIPTION
## What

`/plugin marketplace add stijnvanhulle/template` failed with `Marketplace file not found`. The repo shipped a plugin manifest at `tools/claude/.claude-plugin/plugin.json` but no marketplace catalog, and `/plugin marketplace add` only works against a repo that has `.claude-plugin/marketplace.json` at its root.

## Changes

- Add `.claude-plugin/marketplace.json` at the repo root. It lists the existing `plugin` with `source: "./tools/claude"`, under the marketplace name `stijnvanhulle-template`.
- Fix the documented install string in `README.md`, `AGENTS.md` (and `CLAUDE.md`/`GEMINI.md`/copilot-instructions via symlink), and `tools/claude/README.md`.

A marketplace name is a kebab-case identifier and cannot contain a slash, so `/plugin install` references the manifest name, not the `owner/repo` slug. The slug is only used for `/plugin marketplace add`. Install now reads:

```
/plugin marketplace add stijnvanhulle/template
/plugin install plugin@stijnvanhulle-template
```

## Verify

```
/plugin marketplace add stijnvanhulle/template
/plugin install plugin@stijnvanhulle-template
```

Or locally without a marketplace: `claude --plugin-dir ./tools/claude`

https://claude.ai/code/session_012NBotWfBeFQWNyELg6Fv6q

---
_Generated by [Claude Code](https://claude.ai/code/session_012NBotWfBeFQWNyELg6Fv6q)_