### PR TITLE
refactor(plugin): rename install to toolkit@stijnvanhulle

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
   },
   "plugins": [
     {
-      "name": "template",
+      "name": "toolkit",
       "source": "./tools/claude",
       "description": "Spec-driven workflow, writing-voice skills, code-reviewer agent, and shared TypeScript-monorepo conventions."
     }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,7 +80,7 @@ symlink to it so Claude Code, Gemini CLI, and GitHub Copilot pick up the
 same content. The shared toolset (skills, commands, code-reviewer agent,
 output styles, and conventions) lives in `tools/claude/`, which is also
 packaged as a Claude Code plugin (installable as
-`template@stijnvanhulle`). The `.claude/` and `.agents/skills/`
+`toolkit@stijnvanhulle`). The `.claude/` and `.agents/skills/`
 paths used by the workspace symlink into that folder, so the template repo
 and any project that installs the plugin run the same content.
 Workspace-only pieces (hooks and `settings.json`) stay under `.claude/`.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Agent Skills, and uses symlinks so every tool reads from one source instead of d
 
 `AGENTS.md` is the canonical instruction file. The shared toolset (skills, commands,
 code-reviewer agent, output styles, and conventions) lives in `tools/claude/`, which doubles as
-a Claude Code plugin (installable as `template@stijnvanhulle`). The workspace paths under `.claude/` and `.agents/`
+a Claude Code plugin (installable as `toolkit@stijnvanhulle`). The workspace paths under `.claude/` and `.agents/`
 symlink into that folder, so the template repo and any project that installs the plugin run
 the same content from a single source of truth. See [tools/claude/README.md](tools/claude/README.md)
 for install steps.

--- a/tools/claude/.claude-plugin/plugin.json
+++ b/tools/claude/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
-  "name": "template",
+  "name": "toolkit",
   "displayName": "stijnvanhulle template",
   "version": "0.1.0",
   "description": "Spec-driven workflow, writing-voice skills, code-reviewer agent, and shared TypeScript-monorepo conventions. Extracted from stijnvanhulle/template so other projects can install the same toolset.",

--- a/tools/claude/README.md
+++ b/tools/claude/README.md
@@ -6,8 +6,8 @@ the always-on rules (code style, JSDoc, markdown, security, testing).
 
 The toolkit is extracted from [stijnvanhulle/template](https://github.com/stijnvanhulle/template)
 so the same content powers the template repo itself and any project that installs
-the plugin. It is published under the plugin name `template` from the `stijnvanhulle` marketplace, so the install reads as
-`template@stijnvanhulle`.
+the plugin. It is published under the plugin name `toolkit` from the `stijnvanhulle` marketplace, so the install reads as
+`toolkit@stijnvanhulle`.
 
 ## What you get
 
@@ -39,7 +39,7 @@ spec-driven formatting (`plan`), and a diagrams-first layout (`diagrams-first`).
 ```bash
 # add this repo as a marketplace, then install the plugin
 /plugin marketplace add stijnvanhulle/template
-/plugin install template@stijnvanhulle
+/plugin install toolkit@stijnvanhulle
 ```
 
 To try it locally before publishing:


### PR DESCRIPTION
## What

Rename the plugin from `template` to `toolkit` so the install reads `toolkit@stijnvanhulle`. The marketplace name (`stijnvanhulle`) is unchanged; only the plugin identifier (the part before `@`) changes.

## Changes

- `tools/claude/.claude-plugin/plugin.json`: `name` `template` → `toolkit`
- `.claude-plugin/marketplace.json`: plugin entry `name` `template` → `toolkit`
- Install string updated in `README.md`, `AGENTS.md` (covers `CLAUDE.md`/`GEMINI.md`/copilot via symlink), and `tools/claude/README.md`

## Note

Plugin skills are namespaced by the plugin name, so the slash commands become `/toolkit:spec`, `/toolkit:plan`, etc. for installed-plugin users. The workspace symlinks are unaffected.

## Verify

Validated locally with the Claude CLI (v2.1.173):

```
claude plugin validate .claude-plugin/marketplace.json   # passed
claude plugin validate ./tools/claude                    # passed
claude plugin marketplace add ./.claude-plugin/marketplace.json
claude plugin install toolkit@stijnvanhulle              # installed + enabled
```

After merge, the documented install works:

```
/plugin marketplace add stijnvanhulle/template
/plugin install toolkit@stijnvanhulle
```

https://claude.ai/code/session_012NBotWfBeFQWNyELg6Fv6q

---
_Generated by [Claude Code](https://claude.ai/code/session_012NBotWfBeFQWNyELg6Fv6q)_