### PR TITLE
chore: sync oxlint rules with kubb-labs repos

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -27,10 +27,22 @@ export default defineConfig({
     'default-param-last': 'error',
     'prefer-exponentiation-operator': 'error',
     'typescript/array-type': ['error', { default: 'generic' }],
+    'typescript/consistent-type-assertions': ['error', { assertionStyle: 'as', objectLiteralTypeAssertions: 'allow-as-parameter' }],
     'typescript/consistent-type-imports': ['error', { disallowTypeAnnotations: false }],
+    'typescript/no-explicit-any': 'error',
     'typescript/no-inferrable-types': 'error',
     'typescript/prefer-function-type': 'error',
     'react/self-closing-comp': 'error',
     'react/no-array-index-key': 'warn',
   },
+  overrides: [
+    {
+      // Test fixtures build partial mock objects (`{ ... } as GeneratorContext`) that a
+      // type annotation or `satisfies` cannot express, so the assertion is intentional there.
+      files: ['**/*.test.ts', '**/*.test.tsx'],
+      rules: {
+        'typescript/consistent-type-assertions': 'off',
+      },
+    },
+  ],
 })


### PR DESCRIPTION
## 🎯 Changes

Add `typescript/no-explicit-any` and `typescript/consistent-type-assertions` to `oxlint.config.ts` (with a test-fixture override for the latter), matching the config used across the other kubb-labs repos (kubb, platform, plugins, portfolio). The `plugins` repo enabled these rules first; this brings the rest of the ecosystem in line.

No source violations were found in this repo, so no code changes were needed beyond the config.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](../blob/main/CONTRIBUTING.md).
- [x] I ran the full pre-PR check locally: `pnpm format && pnpm lint:fix && pnpm typecheck && pnpm test`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is for the docs (no release).


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ndd4n2ncQjQjNTuAf5Tzbf)_