### PR TITLE
fix: sync oxlint config with kubb-labs configs

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'oxlint'
 
 export default defineConfig({
-  plugins: ['typescript', 'react'],
+  plugins: ['typescript'],
   ignorePatterns: [
     '**/node_modules/**',
     '**/__snapshots__/**',
@@ -32,16 +32,16 @@ export default defineConfig({
     'typescript/no-explicit-any': 'error',
     'typescript/no-inferrable-types': 'error',
     'typescript/prefer-function-type': 'error',
-    'react/self-closing-comp': 'error',
-    'react/no-array-index-key': 'warn',
   },
   overrides: [
     {
-      // Test fixtures build partial mock objects (`{ ... } as GeneratorContext`) that a
-      // type annotation or `satisfies` cannot express, so the assertion is intentional there.
+      // Test fixtures build partial or intentionally-invalid mock objects (`{ ... } as GeneratorContext`,
+      // `undefined as any`) that a type annotation or `satisfies` cannot express, so assertions and
+      // `any` are intentional there. The source rules stay strict.
       files: ['**/*.test.ts', '**/*.test.tsx'],
       rules: {
         'typescript/consistent-type-assertions': 'off',
+        'typescript/no-explicit-any': 'off',
       },
     },
   ],


### PR DESCRIPTION
## 🎯 Changes

Syncs `oxlint.config.ts` with kubb-labs/kubb and kubb-labs/platform, whose oxfmt options already matched but whose oxlint config had drifted:

- Removes the `react` plugin and its `react/self-closing-comp` / `react/no-array-index-key` rules. This template ships no `.tsx` files or React dependency, so those rules were dead config.
- Aligns the `**/*.test.ts` / `**/*.test.tsx` override to also turn off `typescript/no-explicit-any` alongside `typescript/consistent-type-assertions`, matching kubb and platform, since test fixtures build partial or intentionally-invalid mock objects that need both.

No lint failures result from this change; `pnpm lint` stays green.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](../blob/main/CONTRIBUTING.md).
- [x] I ran the full pre-PR check locally: `pnpm format && pnpm lint:fix && pnpm typecheck && pnpm test`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is for the docs (no release).


---
_Generated by [Claude Code](https://claude.ai/code/session_01NrE2g78FcfWhPUb9CE14bs)_