### PR TITLE
docs: add tools/ to CONTRIBUTING.md folder tree

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,7 @@ pnpm build
 ├── internals/           # Internal, non-published packages (utils)
 ├── configs/             # Shared TypeScript bases and Vitest config
 ├── plans/               # Spec-driven workflow (templates and per-feature folders)
+├── tools/claude/        # Shared agent toolset (skills, commands, code-reviewer agent), packaged as the toolkit plugin
 ├── .changeset/          # Changeset configuration
 ├── .agents/skills/      # Cross-provider agent skills
 ├── .claude/             # Claude rules, commands, agents, output styles, hooks


### PR DESCRIPTION
## 🎯 Changes

Validated `CONTRIBUTING.md` against the current repo. Everything checked out except the folder tree, which omitted the top-level `tools/` directory. `tools/claude/` holds the shared agent toolset (skills, commands, code-reviewer agent) that `.claude/` and `.agents/skills/` symlink into and that ships as the `toolkit` plugin, so it belongs in the tree. Added it.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](../blob/main/CONTRIBUTING.md).
- [ ] I ran the full pre-PR check locally: `pnpm format && pnpm lint:fix && pnpm typecheck && pnpm test`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is for the docs (no release).

---
_Generated by [Claude Code](https://claude.ai/code/session_01K33US8TsjvdWT2ungdVPC3)_