### PR TITLE
fix(plugin): add renames map so template@stijnvanhulle migrates to toolkit

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,5 +14,8 @@
       "source": "./tools/claude",
       "description": "Spec-driven workflow, writing-voice skills, code-reviewer agent, and shared TypeScript-monorepo conventions."
     }
-  ]
+  ],
+  "renames": {
+    "template": "toolkit"
+  }
 }


### PR DESCRIPTION
## 🎯 Changes

Fixes the `/plugin install toolkit@stijnvanhulle` → `Plugin "toolkit" not found in marketplace "stijnvanhulle"` failure that follows the plugin rename.

**Root cause.** PR #160 renamed the marketplace plugin from `template` to `toolkit` (in both `.claude-plugin/marketplace.json` and `tools/claude/.claude-plugin/plugin.json`) but did not add a top-level `renames` entry. The [Claude Code marketplace spec](https://code.claude.com/docs/en/plugin-marketplaces#rename-or-remove-a-plugin) is explicit that renaming a plugin's `name`, or removing it from `plugins`, without a `renames` map strands existing users:

- Anyone who added the marketplace while the plugin was still `template` keeps `template@stijnvanhulle` in their `enabledPlugins`. After the rename that key no longer resolves — a silent `plugin-not-found`.
- Against a pre-rename cached catalog, a fresh `/plugin install toolkit@stijnvanhulle` reports `Plugin "toolkit" not found in marketplace "stijnvanhulle"`, because the cached catalog only knows `template`.

**The fix.** Add a `renames` map to `marketplace.json` pointing the former name at the current one:

```json
"renames": {
  "template": "toolkit"
}
```

On load, Claude Code (v2.1.193+) follows the map, migrates the stale `template@stijnvanhulle` key to `toolkit@stijnvanhulle` in the user, project, and local settings scopes, and shows a one-line `Renamed to "toolkit"` notice instead of erroring. `template` is the only name ever exposed through this marketplace catalog (added in #159, renamed in #160), so it is the only mapping needed.

**Note for anyone still stuck now:** a client whose cached catalog predates the rename should refresh it once with `/plugin marketplace update stijnvanhulle` (or remove and re-add the marketplace); the fresh catalog then carries the rename map.

### Verification

Reproduced end-to-end with the local `claude` CLI (v2.1.211) against a throwaway marketplace that performs the same `template` → `toolkit` rename:

- **Before** (rename, no `renames`): `template@stijnvanhulle` stays stranded in `enabledPlugins` and no longer resolves.
- **After** (`renames` added): the stranded key auto-migrates to `toolkit@stijnvanhulle` on the next session load.
- `claude plugin validate .` → **Validation passed** (no warnings).
- Clean `marketplace add` + `install toolkit@stijnvanhulle` → **Successfully installed**.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](../blob/main/CONTRIBUTING.md).
- [ ] I ran the full pre-PR check locally: `pnpm format && pnpm lint:fix && pnpm typecheck && pnpm test`. — Not run: the change touches only `.claude-plugin/marketplace.json`, which oxfmt/oxlint/tsc/Vitest do not cover. Validated instead with `claude plugin validate .` and a full add/install reproduction.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is for the docs (no release).

Marketplace/plugin configuration change only — no published package is affected, so no changeset and no release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JWMyC4GKPUPo2rCYvDQWGZ)_