### PR TITLE
feat(plugin): add /humanizer command and toolkit install section

### DIFF
--- a/.agents/skills/changelog/SKILL.md
+++ b/.agents/skills/changelog/SKILL.md
@@ -5,7 +5,7 @@ description: Creates user-facing changelogs from git commits by analyzing commit
 
 # Changelog and versioning
 
-Turn technical git commits into polished, user-facing changelog entries. This monorepo uses
+Turn technical git commits into user-facing changelog entries. This monorepo uses
 Changesets for versioning and builds the changelog from changeset entries.
 
 ## When to use

--- a/.agents/skills/conventions/SKILL.md
+++ b/.agents/skills/conventions/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: conventions
-description: Always-on conventions for TypeScript monorepos. Use when writing or reviewing TypeScript, markdown, or tests, when handling secrets, env vars, or input at trust boundaries, or any time you would otherwise reach for a project style guide. Bundles code style, JSDoc, markdown structure, security, and testing rules.
+description: Always-on conventions for TypeScript monorepos. Use when writing or reviewing TypeScript, markdown, or tests, when handling secrets, env vars, or input at trust boundaries, or any time you would otherwise reach for a project style guide. Bundles code style, JSDoc, markdown structure, security, testing, and USA English rules.
 ---
 
 # Conventions

--- a/.agents/skills/documentation/SKILL.md
+++ b/.agents/skills/documentation/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: documentation
-description: Use when writing blog posts or documentation markdown files - provides writing style guide (active voice, present tense), content structure patterns, and SEO optimization. Overrides brevity rules for proper grammar.
+description: Use when writing blog posts or documentation markdown files. Provides a writing style guide (active voice, present tense), content structure patterns, and SEO optimization. Overrides brevity rules for proper grammar.
 ---
 
-# Documentation Skill
+# Documentation skill
 
-This skill provides comprehensive guidelines for AI coding assistants working on documentation.
+Writing guidelines for AI coding assistants working on documentation.
 
-## When to Use
+## When to use
 
 - Adding a new plugin, feature, or option
 - Changing plugin behavior or API signatures
@@ -15,15 +15,16 @@ This skill provides comprehensive guidelines for AI coding assistants working on
 - Writing or updating functionalities/component/composable documentation
 - Optimizing documentation for search engines
 
-## What It Does
+## What it does
 
-- Create clear, concise, practical documentation optimized for developer experience
-- Optimize content for search engines and developer intent
-- Structure content for maximum scannability and engagement
+- Write clear, practical documentation aimed at the developer reading it
+- Match the words developers search for
+- Structure content so a reader can skim it and still find the answer
 
-## Writing Standard
+## Writing standard
 
-**Override**: When writing documentation, maintain proper grammar and complete sentences. The "sacrifice grammar for brevity" rule does NOT apply here.
+When writing documentation, keep proper grammar and complete sentences. The "sacrifice grammar
+for brevity" rule does not apply here.
 
 Documentation must be:
 
@@ -34,78 +35,73 @@ Documentation must be:
 
 Brevity is still valued, but never at the cost of clarity or correctness.
 
-## Available References
+## Available references
 
-| Reference                                                                                              | Purpose                                         |
-|--------------------------------------------------------------------------------------------------------| ----------------------------------------------- |
-| **[../documentation/references/writing-style.md](./../documentation/references/writing-style.md)**     | Voice, tone, sentence structure                 |
-| **[../documentation/references/content-patterns.md](../documentation/references/content-patterns.md)** | Usage patterns, props structure, component patterns |
-| **[../documentation/references/seo-optimization.md](../documentation/references/seo-optimization.md)** | SEO best practices, titles, descriptions, keywords, FAQs |
+| Reference | Purpose |
+| --- | --- |
+| [references/writing-style.md](./references/writing-style.md) | Voice, tone, sentence structure |
+| [references/content-patterns.md](./references/content-patterns.md) | Usage patterns, props structure, component patterns |
+| [references/seo-optimization.md](./references/seo-optimization.md) | SEO practices, titles, descriptions, keywords, FAQs |
 
 To remove AI writing patterns and add voice, use the [humanizer](../humanizer/SKILL.md) skill.
 
-**Load based on context:**
+Load based on context:
 
-- Writing prose → [../documentation/references/writing-style.md](../documentation/references/writing-style.md)
-- Props, options, usage patterns → [../documentation/references/content-patterns.md](../documentation/references/content-patterns.md)
-- Optimizing for search → [../documentation/references/seo-optimization.md](../documentation/references/seo-optimization.md)
+- Writing prose → [references/writing-style.md](./references/writing-style.md)
+- Props, options, usage patterns → [references/content-patterns.md](./references/content-patterns.md)
+- Optimizing for search → [references/seo-optimization.md](./references/seo-optimization.md)
 - Reviewing or editing finished prose → the [humanizer](../humanizer/SKILL.md) skill
 
-## Language and Tone
+## Language and tone
 
 - Use the US spelling. For example, use license, not licence.
 
-## Naming Conventions
+## Naming conventions
 
-- **Use kebab-case**: `how-to-do-thing.md`
-- **Be descriptive**: `multipart-form-data.md` not `form.md`
-- **Match URL structure**: File name becomes the URL path
+File names are kebab-case (`how-to-do-thing.md`) and descriptive: `multipart-form-data.md`, not
+`form.md`. The file name becomes the URL path, so pick it with that in mind.
 
-### Writing Patterns
+### Writing patterns
 
-| Pattern       | Example                                                 |
-| ------------- |---------------------------------------------------------|
+| Pattern | Example |
+| --- | --- |
 | Subject-first | "The `useApp` composable handles Fabric related logic." |
-| Imperative    | "Add the following to `config.ts`."                |
-| Contextual    | "When relying on TypeScript, configure..."              |
+| Imperative | "Add the following to `config.ts`." |
+| Contextual | "When relying on TypeScript, configure..." |
 
-### Modal Verbs
+### Modal verbs
 
-| Verb     | Meaning     |
-| -------- | ----------- |
-| `can`    | Optional    |
+| Verb | Meaning |
+| --- | --- |
+| `can` | Optional |
 | `should` | Recommended |
-| `must`   | Required    |
+| `must` | Required |
 
-### Component Patterns (WHEN to use)
+### Component patterns (when to use)
 
-| Need              | Component                           |
-| ----------------- |-------------------------------------|
-| Info aside        | `> [!NOTE]`                         |
-| Suggestion        | `> [!TIP]`                          |
-| Caution           | `> [!WARNING]`                      |
-| Required          | `> [!IMPORTANT]`                    |
+| Need | Component |
+| --- | --- |
+| Info aside | `> [!NOTE]` |
+| Suggestion | `> [!TIP]` |
+| Caution | `> [!WARNING]` |
+| Required | `> [!IMPORTANT]` |
 | Multi-source code | `::: code-group` and ends with `:::` |
 
 ## Headings
 
-- **H1 (`#`)**: No backticks
-- **H2-H4**: Backticks work fine
+Keep backticks out of the H1. From H2 down they are fine.
 
-## Links and Cross-References
+## Links and cross-references
 
-- **Internal links**: Use relative paths: `/plugins/plugin-ts/`
-- **Anchor links**: Link to specific sections: `/plugins/plugin-ts/#output-path`
-- **External links**: Use full URLs with descriptive text
-- **Placement**: Add links section at the very end of the document
+Internal links use relative paths (`/plugins/plugin-ts/`), and anchors point at a section
+(`/plugins/plugin-ts/#output-path`). External links carry the full URL and descriptive text.
+Put the links section at the very end of the document.
 
 ## Images and assets
 
-- **Location**: `docs/public/`
-- **Reference**: Use relative paths from markdown files
-- **Formats**: Use optimized formats (`webp`/`png`/`jpg`)
-- **Sizing**: Keep file sizes reasonable
-- **Naming**: Use descriptive names: `plugin-react-query-example.png`
+Images live in `docs/public/` and are referenced with relative paths from the markdown file.
+Use `webp`, `png`, or `jpg`, keep the files small, and name them for what they show:
+`plugin-react-query-example.png`.
 
 ## Checklist
 

--- a/.agents/skills/documentation/references/content-patterns.md
+++ b/.agents/skills/documentation/references/content-patterns.md
@@ -1,10 +1,10 @@
-# Content Patterns
+# Content patterns
 
 Blog post structure, frontmatter, and component patterns for documentation.
 
 ## Default
 
-### Default Frontmatter
+### Default frontmatter
 
 Every documentation file must include YAML frontmatter:
 
@@ -16,9 +16,9 @@ outline: deep        # Enables deep table of contents
 ---
 ```
 
-## Package Documentation
+## Package documentation
 
-### Package Documentation Frontmatter
+### Package documentation frontmatter
 
 For packages documentation:
 
@@ -30,24 +30,24 @@ outline: deep
 ---
 ```
 
-### Package Documentation Structure
+### Package documentation structure
 
 Structure for package documentation pages:
 
-1. **Opening** (1-2 paragraphs) - Title and one-sentence description
-2. **Installation**
+1. Opening (1-2 paragraphs): title and one-sentence description
+2. Installation
   - Use code groups (start with `::: code-group` and end with `:::`) for multiple package managers (always include `bun`, `pnpm`, `npm`, `yarn` in that order):
 
 ```shell [bun]
 bun add -d @scope/name
 ```
 
-3. **Options** (one section per option, in logical order)
-  - **Always include Required**: `true` or `false`, never omit
-  - **Always include Default**: If there's a default, specify it. If no default, omit this row
+3. Options (one section per option, in logical order)
+  - Always include `Required:`, either `true` or `false`, never omitted
+  - Always include `Default:` when a default exists. Omit the row when there is none
   - Use following pattern:
 
-```md
+````md
 ### optionName
 
 Brief one-sentence description of what this option does.
@@ -61,24 +61,24 @@ Brief one-sentence description of what this option does.
 | Required: | `false`     |
 |  Default: | `'default'` |
 
-**Example:**
+Example:
 
 ```typescript
 // Show minimal usage example
 ```
-```
-4. **Code examples**
+````
+
+4. Code examples
   - With file path labels
   - All required imports
   - Minimal but complete configuration
-5. **Resources** - Links to docs, repo if relevant
+5. Resources: links to docs, repo if relevant
 
+## Blog post patterns
 
-## Blog Post pattens
+### Blog post frontmatter
 
-### Blog Post Frontmatter
-
-Blog specific Frontmatter rules:
+Blog specific frontmatter rules:
 
 ```yaml
 ---
@@ -95,46 +95,44 @@ category: Release
 ---
 ```
 
-**Categories**: `Release` (version announcements), `Article` (tutorials, guides)
+Categories are `Release` for version announcements and `Article` for tutorials and guides.
 
-### Blog Post Structure
+### Blog post structure
 
-1. **Opening** (1-2 paragraphs) - Announce what's new, why it matters
-2. **Key callout** - `> [!NOTE]`  with requirements/prerequisites
-3. **Feature sections** - `## Emoji Feature Name` headers
-4. **Code examples** - With file path labels
-5. **Breaking changes** - If release post
-6. **Thank you** - Credit contributors
-7. **Resources** - Links to docs, repo
-8. **Release link** - Link to full changelog
+1. Opening (1-2 paragraphs): announce what's new, why it matters
+2. Key callout: `> [!NOTE]` with requirements and prerequisites
+3. Feature sections: `## Emoji Feature Name` headers
+4. Code examples: with file path labels
+5. Breaking changes: if release post
+6. Thank you: credit contributors
+7. Resources: links to docs, repo
+8. Release link: link to full changelog
 
-## Component Patterns
+## Component patterns
 
 Use the right component for the right purpose:
 
-| Need             | Component                            | When                       |
-| ---------------- |--------------------------------------| -------------------------- |
-| Background info  | `> [!NOTE]`                          | Supplementary context      |
-| Best practice    | `> [!TIP]`                           | Recommendations            |
-| Potential issue  | `> [!WARNING]`                       | Things that could go wrong |
-| Must-know        | `> [!IMPORTANT]`                     | Required actions           |
-| Danger           | `> [!CAUTION]`                       | Destructive operations     |
-| Package managers | `::: code-group` and ends with `:::` | `bun`, `pnpm`, `npm`, `yarn` variants     |
+| Need | Component | When |
+| --- | --- | --- |
+| Background info | `> [!NOTE]` | Supplementary context |
+| Best practice | `> [!TIP]` | Recommendations |
+| Potential issue | `> [!WARNING]` | Things that could go wrong |
+| Must-know | `> [!IMPORTANT]` | Required actions |
+| Danger | `> [!CAUTION]` | Destructive operations |
+| Package managers | `::: code-group` and ends with `:::` | `bun`, `pnpm`, `npm`, `yarn` variants |
 
-## Usage Section
-- **Minimal, generic snippet** showing basic syntax
-- Shows core functionality only
-- Uses placeholder/simple values
-- Always includes `::: code-group` with input and output
-- First example users see - keep it simple
+## Usage section
 
-## Examples Section
-- **Realistic, concrete snippets** showing real-world scenarios
-- Demonstrates actual use cases
-- Uses meaningful variable names and realistic data
-- Multiple examples for different scenarios
+A minimal, generic snippet showing the basic syntax. Core functionality only, placeholder or
+simple values, always inside `::: code-group` with input and output. This is the first example
+a reader sees, so keep it simple.
 
-## Props/Options/Parameters Structure
+## Examples section
+
+Realistic, concrete snippets showing real scenarios: meaningful variable names, realistic data,
+and more than one example when the feature is used in different ways.
+
+## Props, options, and parameters structure
 
 All props, options, and parameters must use this exact table format:
 
@@ -148,27 +146,23 @@ All props, options, and parameters must use this exact table format:
 | Required: | `true`   |
 |  Default: | `value`  |  // Only if a default exists
 
-**Table rules:**
-- **Required rows**:
-  - `Type:` - Always present, show the TypeScript type
-  - `Required:` - Always present, use `true` or `false`
-- **Optional rows**:
-  - `Default:` - Only include if a default value exists
-  - Do not include Default row if there's no default
+Table rules:
 
+- `Type:` is always present and shows the TypeScript type
+- `Required:` is always present and is `true` or `false`
+- `Default:` appears only when a default value exists. Leave the row out otherwise
 
-## Prefer table Pattern
+## Prefer the table pattern
 
 Prefer using table pattern when listing options or multiple items:
 
 ```md
-| Skill                                   | Use For           |
-|-----------------------------------------|-------------------|
-| **[../../changelog/SKILL.md](../../changelog/SKILL.md)** | Update changelogs |
+| Skill | Use for |
+| --- | --- |
+| [../../changelog/SKILL.md](../../changelog/SKILL.md) | Update changelogs |
 ```
 
-
-## Including Shared Content
+## Including shared content
 
 Use VitePress `@include` directive to reuse shared content:
 
@@ -177,7 +171,7 @@ Use VitePress `@include` directive to reuse shared content:
 <!--@include: ../core/contentType.md-->
 ```
 
-## Code Block Labels
+## Code block labels
 
 Always include file path:
 

--- a/.agents/skills/documentation/references/seo-optimization.md
+++ b/.agents/skills/documentation/references/seo-optimization.md
@@ -1,12 +1,12 @@
-# SEO Optimization
+# SEO optimization
 
-Essential SEO guidelines for documentation - titles, descriptions, structure, and FAQs.
+SEO guidelines for documentation: titles, descriptions, structure, and FAQs.
 
-## Frontmatter Requirements
+## Frontmatter requirements
 
 ### Title (≤60 characters)
 
-**Formula:** `[Component/Feature] - [What it does] [Context]`
+Formula: `[Component/Feature] - [What it does] [Context]`
 
 ```yaml
 # Component/API pages
@@ -24,7 +24,7 @@ title: Fabric - JSX Code Generator for TypeScript & Files
 
 ### Description (≤155 characters)
 
-**Formula:** `[Action verb] [feature]. [Primary benefit]. [Secondary benefit].`
+Formula: `[Action verb] [feature]. [Primary benefit]. [Secondary benefit].`
 
 ```yaml
 # Be specific and benefit-focused
@@ -46,11 +46,11 @@ outline: deep
 ---
 ```
 
-## Content Structure
+## Content structure
 
-### Opening Paragraph (2-3 sentences)
+### Opening paragraph (2-3 sentences)
 
-Answer: **What** is it? **Who** is it for? **When** to use it?
+Answer what it is, who it is for, and when to use it.
 
 ```markdown
 # [H1 Title] <Badge if applicable />
@@ -58,25 +58,23 @@ Answer: **What** is it? **Who** is it for? **When** to use it?
 [What it is and does]. Use this [component/feature] when [scenario]. Perfect for [audience and use cases].
 ```
 
-### What/Why/How Sections
+### What, why, and how sections
 
 ```markdown
 ## What is [Topic]?
 
 [2-3 sentence explanation]
 
-## Why Use [Topic]?
+## Why use [Topic]?
 
-- **Benefit 1** - Specific explanation
-- **Benefit 2** - Specific explanation
-- **Benefit 3** - Specific explanation
+[Two or three sentences on what it saves the reader, with numbers where you have them]
 
-## How to Use
+## How to use
 
 [Minimal code example with explanation]
 ```
 
-### FAQ Section (3-5 questions)
+### FAQ section (3-5 questions)
 
 Target actual search queries users would type:
 
@@ -96,18 +94,18 @@ Target actual search queries users would type:
 [Key differences explained]
 ```
 
-### Internal Links
+### Internal links
 
-Minimum 2-3 per page in "See Also" or "Next Steps":
+Minimum 2-3 per page in "See also" or "Next steps":
 
 ```markdown
-## See Also
+## See also
 
 - [Link to related component/feature]
 - [Link to guide or tutorial]
 - [Link to parent hub page]
 
-## Next Steps
+## Next steps
 
 - [Link to tutorial]
 - [Link to API reference]

--- a/.agents/skills/documentation/references/writing-style.md
+++ b/.agents/skills/documentation/references/writing-style.md
@@ -1,8 +1,8 @@
-# Writing Style
+# Writing style
 
 Sentence structure, voice, tone, and paragraph patterns for documentation.
 
-## Guiding principle, Clarity over marketing
+## Guiding principle: clarity over marketing
 
 Prefer direct, concrete, technical language over marketing phrasing. Be specific about what the code does and how to use it.
 
@@ -22,11 +22,11 @@ When describing a feature, option, or example use this short structure:
 3. When: when to use it versus alternatives (optional).
 4. How: a minimal, working example demonstrating usage.
 
-## Sentence Patterns
+## Sentence patterns
 
 Documentation prefers short, subject-first sentences that state behavior or intent clearly. Aim for sentences under ~20 to 25 words and favor present tense and active voice.
 
-### Subject-First Declarative (60%)
+### Subject-first declarative (60%)
 
 Use to describe what the product, module, or plugin does. Keep the subject first and follow with a concise verb phrase.
 
@@ -35,7 +35,7 @@ The plugin generates TypeScript types from a schema.
 The parser validates schema types during build.
 ```
 
-### Imperative Instructions (25%)
+### Imperative instructions (25%)
 
 Use for step-by-step commands or quick actions. Start with a verb and keep the object direct.
 
@@ -44,7 +44,7 @@ Run `pnpm changeset` to create a changeset.
 Add the plugin to the config file and configure the options.
 ```
 
-### Contextual Openers (15%)
+### Contextual openers (15%)
 
 Use when you need to signal a prerequisite, conditional, or sequence. Begin with words like `When`, `If`, `During`, or `After`.
 
@@ -55,7 +55,7 @@ After installing the module, restart the server.
 
 ## Voice
 
-### Active Voice (85%)
+### Active voice (85%)
 
 Subject performs action. Prefer this.
 
@@ -65,7 +65,7 @@ Subject performs action. Prefer this.
 | You can override defaults       | Defaults can be overridden            |
 | The library handles validation  | Validation is handled by the library  |
 
-### When Passive is OK (15%)
+### When passive is OK (15%)
 
 - Actor unknown: "The file is loaded during startup."
 - Object more important: "Data is cached for 5 minutes."
@@ -73,11 +73,11 @@ Subject performs action. Prefer this.
 
 ## Tense
 
-**Present (90%)**: Instructions and behavior
-**Future (5%)**: Consequences ("This will create an endpoint")
-**Past (5%)**: Changelogs only
+Write instructions and behavior in the present tense, which covers about 90 percent of the text.
+Future tense is for consequences ("This will create an endpoint"), and past tense belongs in
+changelogs.
 
-## Modal Verbs
+## Modal verbs
 
 | Verb     | Meaning           | Example                          |
 | -------- | ----------------- | -------------------------------- |
@@ -88,21 +88,20 @@ Subject performs action. Prefer this.
 
 Avoid weak modals: `might`, `could`, `would`
 
-## Direct Address
+## Direct address
 
-**Guides/tutorials**: Use "you" (70% of content)
-**API references**: Neutral voice, no "you"
+Guides and tutorials address the reader as "you", roughly 70 percent of the content. API
+references stay neutral and drop the "you".
 
 Stay consistent within sections.
 
 ## Paragraphs
 
-**Length**: 1 to 3 sentences per paragraph
-**Structure**: Topic sentence first, then supporting detail
+Keep paragraphs to 1 to 3 sentences, topic sentence first, supporting detail after.
 
-## Opening Sentences
+## Opening sentences
 
-### Page Openings
+### Page openings
 
 Define what it is, its purpose, key benefits:
 
@@ -112,7 +111,7 @@ The CLI offers an easy way to monitor generation progress by invoking the core `
 
 Avoid: "This page describes...", "In this guide...", "Let's explore..."
 
-### Section Openings
+### Section openings
 
 Introduce topic and why it matters:
 
@@ -122,7 +121,7 @@ Introduce topic and why it matters:
 The plugin accepts several options that control its behavior.
 ```
 
-## Tone by Content Type
+## Tone by content type
 
 | Type            | Tone                         |
 | --------------- | ---------------------------- |
@@ -131,7 +130,7 @@ The plugin accepts several options that control its behavior.
 | API Reference   | Precise, neutral             |
 | Troubleshooting | Empathetic, solution-focused |
 
-## Word Choice
+## Word choice
 
 | Avoid           | Use         |
 | --------------- | ----------- |
@@ -142,7 +141,7 @@ The plugin accepts several options that control its behavior.
 | due to the fact | because     |
 | —               | (rewrite the sentence to avoid it) |
 
-## Common Mistakes
+## Common mistakes
 
 - Starting with "It" or "This" (unclear antecedent)
 - Stacking prepositions ("the value of the property of the config")

--- a/.agents/skills/jsdoc/SKILL.md
+++ b/.agents/skills/jsdoc/SKILL.md
@@ -101,7 +101,7 @@ Never use single-line `/** description */`. Always expand to multi-line.
 ```typescript
 /**
  * Maximum number of concurrent callbacks during traversal.
- * Higher values overlap I/O-bound work; lower values reduce memory pressure.
+ * Higher values overlap I/O-bound work, lower values save memory.
  *
  * @default 30
  */

--- a/.agents/skills/pr/SKILL.md
+++ b/.agents/skills/pr/SKILL.md
@@ -3,22 +3,22 @@ name: pr
 description: Rules and checklist for preparing PRs, creating changesets, and releasing packages in the monorepo.
 ---
 
-# PR Skill
+# PR skill
 
 This skill instructs agents on PR preconditions, changeset usage, and reviewer expectations.
 
-## When to Use
+## When to use
 
 - When a user asks how to prepare a PR or what checks are required before merging
 - When guiding contributors to create changesets or update the changelog
 
-## What It Does
+## What it does
 
 - Enforces the PR checklist: `format, lint:fix, typecheck, test`
 - Instructs on creating and using changesets for version bumps
 - Describes release/merge expectations and documentation updates
 
-## Commands to Suggest
+## Commands to suggest
 
 The same sequence is named in `AGENTS.md`, `CONTRIBUTING.md`, and the PR template:
 
@@ -35,8 +35,8 @@ pnpm changeset   # only when a published package changed
 - [ ] No secrets in the PR
 - [ ] Appropriate version bump via changeset
 
-## Related Skills
+## Related skills
 
-| Skill                                              | Use For                          |
-| -------------------------------------------------- | -------------------------------- |
-| **[../changelog/SKILL.md](../changelog/SKILL.md)** | Update changelogs and changesets |
+| Skill | Use for |
+| --- | --- |
+| [../changelog/SKILL.md](../changelog/SKILL.md) | Update changelogs and changesets |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,12 +102,12 @@ Always-on conventions for this repo. Read the file that matches what you
 are doing. The same files ship in the `conventions` skill, so any tool
 that loads `SKILL.md` folders also picks them up on demand.
 
-- [code-style](.agents/skills/conventions/rules/code-style.md) - ESM conventions, naming, imports, exports.
-- [jsdoc](.agents/skills/conventions/rules/jsdoc.md) - Always-on JSDoc essentials. The `jsdoc` skill is the full reference.
-- [markdown](.agents/skills/conventions/rules/markdown.md) - Markdown structure. The `documentation` and `humanizer` skills cover voice and SEO.
-- [security](.agents/skills/conventions/rules/security.md) - Secrets, input validation at trust boundaries, safe shell use.
-- [testing](.agents/skills/conventions/rules/testing.md) - Vitest patterns and what to test.
-- [usa-english](.agents/skills/conventions/rules/usa-english.md) - Write code, comments, and docs in USA English spellings.
+- [code-style](.agents/skills/conventions/rules/code-style.md): ESM conventions, naming, imports, exports.
+- [jsdoc](.agents/skills/conventions/rules/jsdoc.md): Always-on JSDoc essentials. The `jsdoc` skill is the full reference.
+- [markdown](.agents/skills/conventions/rules/markdown.md): Markdown structure. The `documentation` and `humanizer` skills cover voice and SEO.
+- [security](.agents/skills/conventions/rules/security.md): Secrets, input validation at trust boundaries, safe shell use.
+- [testing](.agents/skills/conventions/rules/testing.md): Vitest patterns and what to test.
+- [usa-english](.agents/skills/conventions/rules/usa-english.md): Write code, comments, and docs in USA English spellings.
 
 <skills>
 
@@ -116,9 +116,9 @@ that loads `SKILL.md` folders also picks them up on demand.
 You have new skills. If any skill might be relevant then you MUST read it.
 
 - [changelog](.agents/skills/changelog/SKILL.md) - Creates user-facing changelogs from git commits by analyzing commit history, categorizing changes, and transforming technical commits into clear, customer-friendly release notes.
-- [conventions](.agents/skills/conventions/SKILL.md) - Always-on conventions for TypeScript monorepos. Use when writing or reviewing TypeScript, markdown, or tests, when handling secrets, env vars, or input at trust boundaries, or any time you would otherwise reach for a project style guide. Bundles code style, JSDoc, markdown structure, security, and testing rules.
+- [conventions](.agents/skills/conventions/SKILL.md) - Always-on conventions for TypeScript monorepos. Use when writing or reviewing TypeScript, markdown, or tests, when handling secrets, env vars, or input at trust boundaries, or any time you would otherwise reach for a project style guide. Bundles code style, JSDoc, markdown structure, security, testing, and USA English rules.
 - [deslop](.agents/skills/deslop/SKILL.md) - Remove AI-generated code slop from a branch or diff. Use after writing or generating code to strip unnecessary comments, defensive checks, `any` casts, and style that does not match the surrounding file. For prose and markdown, use the humanizer skill instead.
-- [documentation](.agents/skills/documentation/SKILL.md) - Use when writing blog posts or documentation markdown files - provides writing style guide (active voice, present tense), content structure patterns, and SEO optimization. Overrides brevity rules for proper grammar.
+- [documentation](.agents/skills/documentation/SKILL.md) - Use when writing blog posts or documentation markdown files. Provides a writing style guide (active voice, present tense), content structure patterns, and SEO optimization. Overrides brevity rules for proper grammar.
 - [humanizer](.agents/skills/humanizer/SKILL.md) - Remove AI writing patterns to make documentation sound natural, specific, and human. Covers content patterns, language patterns, style patterns, and communication patterns.
 - [jsdoc](.agents/skills/jsdoc/SKILL.md) - Full JSDoc format guide for TypeScript, covering @example formats (short, multi-line, multi-variant), tag usage (@default, @deprecated, what to avoid), documentation patterns for properties/enums/functions, and tag order.
 - [pr](.agents/skills/pr/SKILL.md) - Rules and checklist for preparing PRs, creating changesets, and releasing packages in the monorepo.

--- a/README.md
+++ b/README.md
@@ -39,6 +39,32 @@ workspace paths under `.cursor/` symlink into it, and `.cursor-plugin/marketplac
 installable from Cursor's marketplace. See [tools/cursor/README.md](tools/cursor/README.md) for
 install steps.
 
+### Install the toolkit
+
+[![Install in Claude Code][claude-install-src]][claude-install-href] [![Install in Cursor][cursor-install-src]][cursor-install-href]
+
+Both tools install the same `toolkit` plugin from this repo's marketplace, in two steps: add the
+marketplace, then install the plugin.
+
+Claude Code, from any shell:
+
+```bash
+claude plugin marketplace add stijnvanhulle/template && claude plugin install toolkit@stijnvanhulle
+```
+
+Cursor, from any shell (`agent` is the Cursor CLI):
+
+```bash
+agent plugin marketplace add https://github.com/stijnvanhulle/template
+agent plugin install toolkit@stijnvanhulle
+```
+
+The badges link to the per-tool steps, they do not install on click. Neither tool has a URL
+scheme that installs a plugin from a third-party marketplace, so no link can open the app and
+do it for you. Cursor's one deeplink, `cursor://anysphere.cursor-deeplink/mcp/install`, handles
+MCP servers, and the Claude Code equivalent is an
+[open feature request](https://github.com/anthropics/claude-code/issues/62481).
+
 ### Folder structure
 
 ```
@@ -54,14 +80,14 @@ tools/claude/                                 # distributable Claude Code plugin
 ├── .claude-plugin/plugin.json                # plugin manifest
 ├── README.md                                 # install + usage
 ├── skills → ../../.agents/skills             # shared skills (canonical home is .agents/skills)
-├── commands/                                 # slash commands: /changeset, /deslop, /spec, /plan, /implement, /verify
+├── commands/                                 # slash commands: /changeset, /deslop, /humanizer, /spec, /plan, /implement, /verify
 ├── agents/                                   # subagents: code-reviewer
 └── output-styles/                            # system-prompt modes: house (default), plan, diagrams-first
 tools/cursor/                                 # distributable Cursor plugin (same toolset, Cursor formats)
 ├── .cursor-plugin/plugin.json                # plugin manifest
 ├── README.md                                 # install + usage
 ├── rules/                                    # Cursor rules (.mdc): code-style, jsdoc, markdown, security, testing, usa-english
-├── commands/                                 # slash commands: /changeset, /deslop, /spec, /plan, /implement, /verify
+├── commands/                                 # slash commands: /changeset, /deslop, /humanizer, /spec, /plan, /implement, /verify
 ├── agents/                                   # subagents: code-reviewer
 └── skills → ../../.agents/skills             # shared skills (canonical home is .agents/skills)
 .cursor-plugin/marketplace.json               # Cursor marketplace manifest (lists the toolkit plugin)
@@ -194,3 +220,7 @@ See [CONTRIBUTING.md](./CONTRIBUTING.md) for the project structure, prerequisite
 [license-href]: https://github.com/stijnvanhulle/template/blob/main/LICENSE
 [coverage-src]: https://shieldcn.dev/codecov/github/stijnvanhulle/template.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [coverage-href]: https://app.codecov.io/gh/stijnvanhulle/template
+[claude-install-src]: https://img.shields.io/badge/Install%20in-Claude%20Code-D97757?logo=claude&logoColor=white&style=for-the-badge
+[claude-install-href]: tools/claude/README.md#install
+[cursor-install-src]: https://img.shields.io/badge/Install%20in-Cursor-1A1A1A?logo=cursor&logoColor=white&style=for-the-badge
+[cursor-install-href]: tools/cursor/README.md#install

--- a/README.md
+++ b/README.md
@@ -150,20 +150,20 @@ Claude-specific extensions layer on top. The pieces, and when each one loads:
 
 | Path | What it does | When it loads |
 |---|---|---|
-| `.claude/rules/` → `.agents/skills/conventions/rules/` | Always-on conventions: code style, JSDoc, markdown, security, testing | Session start, or when a matching file opens for path-scoped rules |
+| `.claude/rules/` → `.agents/skills/conventions/rules/` | Always-on conventions: code style, JSDoc, markdown, security, testing, USA English | Session start, or when a matching file opens for path-scoped rules |
 | `.claude/skills/` → `.agents/skills/` | Playbooks: changelog, deslop, documentation, humanizer, jsdoc, pr, spec-driven, conventions | On demand, when the task matches the skill description |
 | `.claude/commands/` → `tools/claude/commands/` | Explicit slash-command actions, such as `/changeset` and `/deslop` | When you type the command |
 | `.claude/agents/` → `tools/claude/agents/` | Subagents with their own context window, such as `code-reviewer` | When delegated a matching task |
 | `.claude/output-styles/` → `tools/claude/output-styles/` | System-prompt modes: `house` (the default, set in `settings.json`), `plan`, and `diagrams-first` | At session start (house), or when selected |
-| `.claude/hooks/` | Scripts that install deps on session start and format files on edit | On the matching event |
-| `.claude/settings.json` | Permissions and hook registration | Always |
+| `.claude/hooks/` | Scripts that install deps in remote sessions, refuse edits to the lockfile and to build output, and format and lint once a turn ends | On the matching event |
+| `.claude/settings.json` | Permissions, hook registration, and the default output style | Always |
 
 The guiding split: rules always apply, skills are optional expertise loaded only when
 relevant, and commands are actions you trigger yourself.
 
 For larger features, `plans/` holds a spec-driven workflow (spec, research, plan, slices,
-verification) driven by the `spec-driven` skill and the `/spec`, `/plan`, and `/verify`
-commands. See [plans/README.md](plans/README.md). For quick changes, use the `plan` output
+verification) driven by the `spec-driven` skill and the `/spec`, `/plan`, `/implement`, and
+`/verify` commands. See [plans/README.md](plans/README.md). For quick changes, use the `plan` output
 style instead.
 
 ## Using this template

--- a/README.md
+++ b/README.md
@@ -59,10 +59,10 @@ agent plugin marketplace add https://github.com/stijnvanhulle/template
 agent plugin install toolkit@stijnvanhulle
 ```
 
-The badges link to the per-tool steps, they do not install on click. Neither tool has a URL
-scheme that installs a plugin from a third-party marketplace, so no link can open the app and
-do it for you. Cursor's one deeplink, `cursor://anysphere.cursor-deeplink/mcp/install`, handles
-MCP servers, and the Claude Code equivalent is an
+The badges link to those steps. Clicking one does not install anything, because neither tool has
+a URL scheme that installs a plugin from a third-party marketplace. Cursor's one deeplink,
+`cursor://anysphere.cursor-deeplink/mcp/install`, is for MCP servers, and the Claude Code
+equivalent is still an
 [open feature request](https://github.com/anthropics/claude-code/issues/62481).
 
 ### Folder structure

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,6 @@
-# Security Policy
+# Security policy
 
-## Supported Versions
+## Supported versions
 
 | Version | Supported          |
 | ------- | ------------------ |

--- a/tools/claude/README.md
+++ b/tools/claude/README.md
@@ -2,7 +2,7 @@
 
 A reusable toolkit for TypeScript monorepos: a spec-driven workflow, writing-voice
 skills, a code-reviewer agent, output styles, and a `conventions` skill that ships
-the always-on rules (code style, JSDoc, markdown, security, testing).
+the always-on rules (code style, JSDoc, markdown, security, testing, USA English).
 
 The toolkit is extracted from [stijnvanhulle/template](https://github.com/stijnvanhulle/template)
 so the same content powers the template repo itself and any project that installs
@@ -30,8 +30,8 @@ Skills loaded on demand from their descriptions:
 - `jsdoc` covers JSDoc tags and examples for TypeScript.
 - `pr` is the PR-prep and release checklist for a Changesets monorepo.
 - `spec-driven` drives the spec → plan → implement → verify loop.
-- `conventions` bundles the five always-on rules (code style, JSDoc, markdown,
-  security, testing).
+- `conventions` bundles the six always-on rules (code style, JSDoc, markdown,
+  security, testing, USA English).
 
 A `code-reviewer` subagent reviews TypeScript changes for correctness, security,
 and maintainability. Three output styles set the writing voice (`house`),
@@ -82,8 +82,8 @@ Skills load on their own. Each carries a description, and the agent reads the ma
 the task fits, so writing release notes pulls in `changelog` and cleaning prose pulls in
 `humanizer` without being asked. To force one, name it: "use the deslop skill on this diff."
 
-The `conventions` rules (code style, JSDoc, markdown, security, testing) are always on and need
-no trigger. The guiding split: rules always apply, skills are optional expertise loaded when
+The `conventions` rules (code style, JSDoc, markdown, security, testing, USA English) are always
+on and need no trigger. The guiding split: rules always apply, skills are optional expertise loaded when
 relevant, and commands are actions you trigger yourself.
 
 ## Scope

--- a/tools/claude/README.md
+++ b/tools/claude/README.md
@@ -19,6 +19,7 @@ Slash commands for the spec-driven workflow and releases:
 - `/verify <feature>` checks the implementation against the spec.
 - `/changeset [patch|minor|major]` creates Changesets for affected packages.
 - `/deslop [path]` removes AI-generated code slop from the branch's changes.
+- `/humanizer [path]` removes AI writing patterns from the prose the branch changed.
 
 Skills loaded on demand from their descriptions:
 
@@ -38,8 +39,19 @@ spec-driven formatting (`plan`), and a diagrams-first layout (`diagrams-first`).
 
 ## Install
 
+One command from any shell, no session needed:
+
 ```bash
-# add this repo as a marketplace, then install the plugin
+claude plugin marketplace add stijnvanhulle/template && claude plugin install toolkit@stijnvanhulle
+```
+
+It installs to user scope. Pass `--scope project` on the install to share it with everyone who
+clones the repository, or `--scope local` to keep it to yourself in one repository. Start Claude
+Code again, or run `/reload-plugins` in an open session, to activate it.
+
+The same two steps inside a session:
+
+```bash
 /plugin marketplace add stijnvanhulle/template
 /plugin install toolkit@stijnvanhulle
 ```
@@ -58,6 +70,7 @@ argument:
 ```bash
 /deslop                    # strip AI code slop from the whole branch diff
 /deslop apps/web           # limit it to one path
+/humanizer docs            # rewrite the prose the branch changed under docs/
 /spec offline-mode         # start a spec-driven feature
 /plan offline-mode         # turn the spec into a numbered plan
 /implement offline-mode    # work the next plan slice

--- a/tools/claude/README.md
+++ b/tools/claude/README.md
@@ -39,15 +39,15 @@ spec-driven formatting (`plan`), and a diagrams-first layout (`diagrams-first`).
 
 ## Install
 
-One command from any shell, no session needed:
+Install from any shell, without opening a session:
 
 ```bash
 claude plugin marketplace add stijnvanhulle/template && claude plugin install toolkit@stijnvanhulle
 ```
 
-It installs to user scope. Pass `--scope project` on the install to share it with everyone who
-clones the repository, or `--scope local` to keep it to yourself in one repository. Start Claude
-Code again, or run `/reload-plugins` in an open session, to activate it.
+That installs to user scope. Pass `--scope project` to share it with everyone who clones the
+repository, or `--scope local` to keep it to yourself in one repository. Restart Claude Code to
+load it, or run `/reload-plugins` in a session that is already open.
 
 The same two steps inside a session:
 

--- a/tools/claude/commands/humanizer.md
+++ b/tools/claude/commands/humanizer.md
@@ -1,0 +1,20 @@
+---
+argument-hint: [path]
+description: Remove AI writing patterns from the prose changed on the current branch
+---
+
+!`git diff --stat HEAD`
+
+Rewrite the user-facing prose on this branch so it reads as human.
+
+1. Review the branch's prose changes: the diff against the default branch, narrowed to
+   `$ARGUMENTS` when a path or glob is given. READMEs, docs, and changesets count, code does not.
+2. Strip the AI tells: dashes and semicolons used as punctuation, title-case headings, emoji,
+   marketing words, rule-of-three lists, inline-header bullets, hedging, and filler openers.
+3. Put voice back: vary sentence rhythm, keep the specific detail, and react to the facts
+   instead of only listing them.
+4. Keep the meaning and the structure. Do not invent facts, and leave code samples and quoted
+   upstream text as they are.
+5. Report a 1-3 sentence summary of the tells you fixed.
+
+Follow the `humanizer` skill for the full pattern list. For code, use the `deslop` skill instead.

--- a/tools/claude/commands/implement.md
+++ b/tools/claude/commands/implement.md
@@ -11,7 +11,7 @@ Execute the slices for **$ARGUMENTS** from `plans/$ARGUMENTS/plan.md` and its
    its Verification commands. Keep the slice runnable before moving on.
 3. When a slice's Verification passes, tick its Done criteria in that slice file (`- [ ]` to
    `- [x]`).
-4. If a slice's Verification fails, fix it or stop and report; do not check unmet criteria or
+4. If a slice's Verification fails, fix it or stop and report. Do not check unmet criteria or
    start the next slice.
 5. Once every slice's Done criteria pass, run `/verify $ARGUMENTS` for the feature-level closeout.
 

--- a/tools/cursor/README.md
+++ b/tools/cursor/README.md
@@ -24,8 +24,9 @@ Slash commands for the spec-driven workflow and releases:
 
 Rules that Cursor auto-attaches by file type, or applies always:
 
-- `code-style`, `jsdoc`, and `testing` attach when you edit matching TypeScript files.
-- `markdown` attaches when you edit markdown.
+- `code-style` attaches on `.ts`, `.tsx`, and `.vue` files, `jsdoc` on `.ts` and `.tsx`.
+- `testing` attaches on `*.test.*` and `*.spec.*` files.
+- `markdown` attaches on `.md` and `.mdx`.
 - `security` and `usa-english` apply on every request.
 
 Skills loaded on demand from their descriptions:

--- a/tools/cursor/README.md
+++ b/tools/cursor/README.md
@@ -20,6 +20,7 @@ Slash commands for the spec-driven workflow and releases:
 - `/verify <feature>` checks the implementation against the spec.
 - `/changeset [patch|minor|major]` creates Changesets for affected packages.
 - `/deslop [path]` removes AI-generated code slop from the branch's changes.
+- `/humanizer [path]` removes AI writing patterns from the prose the branch changed.
 
 Rules that Cursor auto-attaches by file type, or applies always:
 
@@ -43,9 +44,27 @@ and maintainability. It is read-only and runs in its own context.
 
 ## Install
 
-Add this repo as a marketplace in Cursor's Customize page (Settings, Customize,
-Marketplaces), then install the `toolkit` plugin from it. The marketplace manifest
-lives at the repo root in `.cursor-plugin/marketplace.json`.
+Add the marketplace, then install the plugin. From any shell, with the Cursor CLI (`agent`):
+
+```bash
+agent plugin marketplace add https://github.com/stijnvanhulle/template
+agent plugin install toolkit@stijnvanhulle
+```
+
+The same two steps work as `/plugin` inside a Cursor CLI session, and in the editor under
+Settings, Customize, Marketplaces. The manifest Cursor reads is
+`.cursor-plugin/marketplace.json` at the repo root.
+
+This plugin's `skills/` is a symlink to `.agents/skills` at the repo root, so an install that
+fetches only `tools/cursor/` leaves the link dangling and the skills do not load. When that
+happens, clone the whole repo into Cursor's local plugin folder so the symlink resolves:
+
+```bash
+git clone https://github.com/stijnvanhulle/template.git ~/.cursor/plugins/local/toolkit
+```
+
+Cursor has no plugin deeplink, so there is no one-click install button. Its only deeplink today,
+`cursor://anysphere.cursor-deeplink/mcp/install`, installs MCP servers, not plugins.
 
 To try it locally before publishing, point Cursor at this folder as a workspace
 plugin, or copy `rules/`, `commands/`, and `agents/` into a project's `.cursor/`
@@ -58,6 +77,7 @@ Slash commands run when you type them. Name the command and pass any argument:
 ```text
 /deslop                    # strip AI code slop from the whole branch diff
 /deslop apps/web           # limit it to one path
+/humanizer docs            # rewrite the prose the branch changed under docs/
 /spec offline-mode         # start a spec-driven feature
 /plan offline-mode         # turn the spec into a numbered plan
 /implement offline-mode    # work the next plan slice

--- a/tools/cursor/commands/changeset.md
+++ b/tools/cursor/commands/changeset.md
@@ -1,3 +1,8 @@
+---
+name: changeset
+description: Create a Changeset for the current changes with the right semver bump
+---
+
 Create a Changeset for the current changes on this branch.
 
 1. Review the changes (the diff against the default branch) and determine which workspace packages

--- a/tools/cursor/commands/deslop.md
+++ b/tools/cursor/commands/deslop.md
@@ -1,3 +1,8 @@
+---
+name: deslop
+description: Remove AI-generated code slop from the current branch's changes
+---
+
 Remove AI-generated code slop from the changes on this branch.
 
 1. Review the branch's changes: the diff against the default branch, narrowed to `$1` when a path

--- a/tools/cursor/commands/humanizer.md
+++ b/tools/cursor/commands/humanizer.md
@@ -1,3 +1,8 @@
+---
+name: humanizer
+description: Remove AI writing patterns from the prose changed on the current branch
+---
+
 Rewrite the user-facing prose on this branch so it reads as human.
 
 1. Review the branch's prose changes: the diff against the default branch, narrowed to `$1` when

--- a/tools/cursor/commands/humanizer.md
+++ b/tools/cursor/commands/humanizer.md
@@ -1,0 +1,13 @@
+Rewrite the user-facing prose on this branch so it reads as human.
+
+1. Review the branch's prose changes: the diff against the default branch, narrowed to `$1` when
+   a path or glob is given. READMEs, docs, and changesets count, code does not.
+2. Strip the AI tells: dashes and semicolons used as punctuation, title-case headings, emoji,
+   marketing words, rule-of-three lists, inline-header bullets, hedging, and filler openers.
+3. Put voice back: vary sentence rhythm, keep the specific detail, and react to the facts
+   instead of only listing them.
+4. Keep the meaning and the structure. Do not invent facts, and leave code samples and quoted
+   upstream text as they are.
+5. Report a 1-3 sentence summary of the tells you fixed.
+
+Follow the `humanizer` skill for the full pattern list. For code, use the `deslop` skill instead.

--- a/tools/cursor/commands/implement.md
+++ b/tools/cursor/commands/implement.md
@@ -1,3 +1,8 @@
+---
+name: implement
+description: Work a feature's slices one at a time, ticking each slice's Done criteria as it passes
+---
+
 Execute the slices for the feature **$1** from `plans/$1/plan.md` and its `NNN-<slug>.md` slice files.
 
 1. Confirm `plans/$1/plan.md` and at least one slice file exist. If not, run `/plan` first.

--- a/tools/cursor/commands/implement.md
+++ b/tools/cursor/commands/implement.md
@@ -9,7 +9,7 @@ Execute the slices for the feature **$1** from `plans/$1/plan.md` and its `NNN-<
 2. Work the slices in numbered order, one at a time. For each slice: follow its Steps, then run its
    Verification commands. Keep the slice runnable before moving on.
 3. When a slice's Verification passes, tick its Done criteria in that slice file (`- [ ]` to `- [x]`).
-4. If a slice's Verification fails, fix it or stop and report; do not check unmet criteria or start
+4. If a slice's Verification fails, fix it or stop and report. Do not check unmet criteria or start
    the next slice.
 5. Once every slice's Done criteria pass, run `/verify $1` for the feature-level closeout.
 

--- a/tools/cursor/commands/plan.md
+++ b/tools/cursor/commands/plan.md
@@ -1,3 +1,8 @@
+---
+name: plan
+description: Turn a feature's spec and research into its plan.md (architecture and numbered slices) and scaffold the slice files
+---
+
 Produce the Phase 2 plan for the feature **$1** from `plans/$1/spec.md` and `plans/$1/research.md`.
 
 1. Confirm the spec exists and its acceptance criteria (`AC-N`) are clear. If not, run `/spec` first.

--- a/tools/cursor/commands/spec.md
+++ b/tools/cursor/commands/spec.md
@@ -1,3 +1,8 @@
+---
+name: spec
+description: Draft or refine the Phase 0 spec (requirements and acceptance criteria) for a feature
+---
+
 Write the specification for the feature **$1**.
 
 Copy `plans/templates/spec.md` to `plans/$1/spec.md` and fill it in.

--- a/tools/cursor/commands/verify.md
+++ b/tools/cursor/commands/verify.md
@@ -1,3 +1,8 @@
+---
+name: verify
+description: Fill a feature's verification.md with scenarios mapped to acceptance criteria, then run them
+---
+
 Write and run the closeout verification for the feature **$1** from `plans/$1/spec.md`.
 
 1. Copy `plans/templates/verification.md` to `plans/$1/verification.md` if it does not exist yet.


### PR DESCRIPTION
## 🎯 Changes

Adds an install section for the `toolkit` plugin, ships `/humanizer` as a slash command in both plugins, gives the Cursor commands the frontmatter they were missing, and corrects stale claims across the docs.

Install docs:

- Root README gets an "Install the toolkit" section with two badges and the shell commands for each tool: `claude plugin marketplace add stijnvanhulle/template && claude plugin install toolkit@stijnvanhulle`, and `agent plugin marketplace add https://github.com/stijnvanhulle/template` followed by `agent plugin install toolkit@stijnvanhulle`.
- `tools/claude/README.md` leads with the non-interactive shell install, notes the `--scope` options, and keeps the in-session slash commands as the second path.
- `tools/cursor/README.md` uses the Cursor CLI commands and records the symlink caveat: `skills/` points at `.agents/skills` in the repo root, so an install that fetches only `tools/cursor/` leaves it dangling, and a full clone into `~/.cursor/plugins/local/toolkit` resolves it.

The badges link to those steps, they do not install on click. Neither tool has a URL scheme that installs a plugin from a third-party marketplace: Cursor's only deeplink is `cursor://anysphere.cursor-deeplink/mcp/install` for MCP servers, and the Claude Code equivalent is [an open feature request](https://github.com/anthropics/claude-code/issues/62481).

New command:

- `tools/claude/commands/humanizer.md` and `tools/cursor/commands/humanizer.md`, mirroring `/deslop` but for prose. Both take an optional path, strip the AI writing tells, and defer to the `humanizer` skill for the full pattern list.

Cursor command frontmatter:

- All seven `tools/cursor/commands/*.md` files shipped without frontmatter, so Cursor had no title or description to show. Each now carries `name` and `description`, matching the Claude commands.

Doc corrections found by validating every README claim against the repo:

- The `conventions` bundle is six rules, not five. `usa-english` was missing from the skill description, the AGENTS.md copy of it, the root README table, and three spots in the Claude plugin README.
- The `.claude/hooks/` row said format-lint runs on edit. It runs on Stop, and the row never mentioned the edit guard.
- The `.claude/settings.json` row omitted the default output style it sets.
- The spec-driven sentence listed `/spec`, `/plan`, and `/verify` but not `/implement`.
- The Cursor rules list now names the real globs: `testing` attaches on test files, not all TypeScript.

Humanizer pass over every markdown file, skipping the Contributor Covenant, the generated `.changeset/README.md`, the humanizer and documentation reference files that quote bad patterns on purpose, and `.github/pull_request_template.md`, whose emoji headings look deliberate. It removes title-case headings, spaced-hyphen separators, bold labels mid-sentence, inline-header bullet lists, and two clause-joining semicolons.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](../blob/main/CONTRIBUTING.md).
- [x] I ran the full pre-PR check locally: `pnpm format && pnpm lint:fix && pnpm typecheck && pnpm test`.

Also ran `claude plugin validate` on the plugin and marketplace manifests (both pass), verified the Claude install path end to end in a clean container, and checked that every code fence in the repo's markdown is balanced.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is for the docs (no release).

https://claude.ai/code/session_01HAAp4DK8u6D2pWJnKufJTG