### PR TITLE
docs: tell agents to bump toolkit manifest versions with skill changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,6 +84,15 @@ For the full wiring (which path symlinks where, plugin manifests, install steps)
 the per-agent READMEs under `tools/` and the
 [README](README.md#ai-assistant-configuration).
 
+Four toolkit manifests ship this content and each carries its own `version` field:
+`tools/claude/.claude-plugin/plugin.json`, `tools/cursor/.cursor-plugin/plugin.json`,
+`.codex-plugin/plugin.json`, and `gemini-extension.json`. `claude plugin update` (and
+the Cursor and Codex equivalents) compare that field to decide whether there's anything
+new, so a content change with no version bump makes the update look like a no-op. When
+a change touches `.agents/skills/`, `tools/claude/`, or `tools/cursor/`, bump the
+`version` in every manifest whose content it affects (a semver patch bump for most
+changes) in the same PR.
+
 ## Rules
 
 Conventions for this repo. `plain-language`, `security`, and `usa-english` apply to

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -86,6 +86,15 @@ For the full wiring (which path symlinks where, plugin manifests, install steps)
 the per-agent READMEs under `tools/` and the
 [README](README.md#ai-assistant-configuration).
 
+Four toolkit manifests ship this content and each carries its own `version` field:
+`tools/claude/.claude-plugin/plugin.json`, `tools/cursor/.cursor-plugin/plugin.json`,
+`.codex-plugin/plugin.json`, and `gemini-extension.json`. `claude plugin update` (and
+the Cursor and Codex equivalents) compare that field to decide whether there's anything
+new, so a content change with no version bump makes the update look like a no-op. When
+a change touches `.agents/skills/`, `tools/claude/`, or `tools/cursor/`, bump the
+`version` in every manifest whose content it affects (a semver patch bump for most
+changes) in the same PR.
+
 ## Rules
 
 Conventions for this repo. `plain-language`, `security`, and `usa-english` apply to


### PR DESCRIPTION
## 🎯 Changes

#197 bumped the four toolkit manifests after they drifted through two content-changing
merges with no version bump, which made `claude plugin update` report "already latest"
with real content waiting to ship. Nothing in `AGENTS.md` told an agent that a manifest
version bump is part of a skill or rule change, so the same drift can happen again.

- Add a note to the "How agents read this repo" section of `AGENTS.md` naming the four
  manifests (`tools/claude/.claude-plugin/plugin.json`,
  `tools/cursor/.cursor-plugin/plugin.json`, `.codex-plugin/plugin.json`,
  `gemini-extension.json`) and telling an agent to bump the affected ones in the same PR
  as a `.agents/skills/`, `tools/claude/`, or `tools/cursor/` change.
- Regenerate `GEMINI.md` with `pnpm agent-files --write` to carry the same text (Gemini
  has no on-demand skill loading, so its context file inlines `AGENTS.md`).

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](../CONTRIBUTING.md).
- [x] I ran the full pre-PR check locally: `pnpm format && pnpm lint:fix && pnpm typecheck && pnpm test`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is for the docs (no release).

---
_Generated by [Claude Code](https://claude.ai/code/session_01HRuvQGTkuR3W86iSoUcyi7)_