### PR TITLE
feat: version the Claude and Cursor plugins with Changesets

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -16,5 +16,9 @@
   "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
     "onlyUpdatePeerDependentsWhenOutOfRange": true
   },
-  "ignore": ["@internals/*"]
+  "ignore": ["@internals/*"],
+  "privatePackages": {
+    "version": true,
+    "tag": false
+  }
 }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,8 @@ on:
     paths:
       - '.changeset/**'
       - 'packages/**'
+      - 'tools/claude/**'
+      - 'tools/cursor/**'
 
 permissions: {}
 
@@ -45,7 +47,9 @@ jobs:
         id: changesets
         uses: changesets/action@8488615a623b1b9c987934bb89eae8af6a946ac1 # v2.1.1
         with:
-          version-script: pnpm exec changeset version
+          # Keeps the Claude and Cursor plugin manifests' version fields in step with
+          # the @stijnvanhulle/template-{claude,cursor}-plugin packages Changesets bumps.
+          version-script: pnpm exec changeset version && pnpm run sync:plugin-version
           publish-script: pnpm release
           commit-message: 'ci(changesets): version packages'
           pr-title: 'ci(changesets): version packages'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,10 +88,17 @@ Four toolkit manifests ship this content and each carries its own `version` fiel
 `tools/claude/.claude-plugin/plugin.json`, `tools/cursor/.cursor-plugin/plugin.json`,
 `.codex-plugin/plugin.json`, and `gemini-extension.json`. `claude plugin update` (and
 the Cursor and Codex equivalents) compare that field to decide whether there's anything
-new, so a content change with no version bump makes the update look like a no-op. When
-a change touches `.agents/skills/`, `tools/claude/`, or `tools/cursor/`, bump the
-`version` in every manifest whose content it affects (a semver patch bump for most
-changes) in the same PR.
+new, so a content change with no version bump makes the update look like a no-op.
+
+The Claude and Cursor manifests are versioned through Changesets: `tools/claude` and
+`tools/cursor` are private workspace packages (`@stijnvanhulle/template-claude-plugin`,
+`@stijnvanhulle/template-cursor-plugin`) in the same `fixed` group as every other
+`@stijnvanhulle/template-*` package. Add a changeset when you change either plugin's
+content; release syncs the bumped version into the matching `plugin.json` automatically
+(`scripts/syncPluginVersion.mjs`), so never edit those two `version` fields by hand.
+`.codex-plugin/plugin.json` and `gemini-extension.json` aren't tied to a workspace
+package yet, so when a change touches `.agents/skills/` (which both of those also ship),
+bump their `version` by hand in the same PR.
 
 ## Rules
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -90,10 +90,17 @@ Four toolkit manifests ship this content and each carries its own `version` fiel
 `tools/claude/.claude-plugin/plugin.json`, `tools/cursor/.cursor-plugin/plugin.json`,
 `.codex-plugin/plugin.json`, and `gemini-extension.json`. `claude plugin update` (and
 the Cursor and Codex equivalents) compare that field to decide whether there's anything
-new, so a content change with no version bump makes the update look like a no-op. When
-a change touches `.agents/skills/`, `tools/claude/`, or `tools/cursor/`, bump the
-`version` in every manifest whose content it affects (a semver patch bump for most
-changes) in the same PR.
+new, so a content change with no version bump makes the update look like a no-op.
+
+The Claude and Cursor manifests are versioned through Changesets: `tools/claude` and
+`tools/cursor` are private workspace packages (`@stijnvanhulle/template-claude-plugin`,
+`@stijnvanhulle/template-cursor-plugin`) in the same `fixed` group as every other
+`@stijnvanhulle/template-*` package. Add a changeset when you change either plugin's
+content; release syncs the bumped version into the matching `plugin.json` automatically
+(`scripts/syncPluginVersion.mjs`), so never edit those two `version` fields by hand.
+`.codex-plugin/plugin.json` and `gemini-extension.json` aren't tied to a workspace
+package yet, so when a change touches `.agents/skills/` (which both of those also ship),
+bump their `version` by hand in the same PR.
 
 ## Rules
 

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "lint:fix": "oxlint -c oxlint.config.ts --fix ./packages",
     "release": "changeset publish",
     "start": "turbo run start --filter=./packages/* --filter=./internals/*",
+    "sync:plugin-version": "node scripts/syncPluginVersion.mjs",
     "test": "vitest run --config ./configs/vitest.config.ts",
     "test:bench": "NODE_OPTIONS='--max_old_space_size=4096' vitest bench --config ./configs/vitest.bench.config.ts",
     "test:watch": "vitest --config ./configs/vitest.config.ts",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -118,6 +118,10 @@ importers:
         specifier: 'catalog:'
         version: 4.1.11(@types/node@22.20.1)(@vitest/coverage-v8@4.1.11)(@vitest/ui@4.1.11)(vite@8.0.13(@types/node@22.20.1)(jiti@2.7.0)(yaml@2.9.0))
 
+  tools/claude: {}
+
+  tools/cursor: {}
+
 packages:
 
   '@antfu/ni@30.5.0':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,7 @@
 packages:
   - packages/*
   - internals/*
+  - tools/*
 allowBuilds:
   "@parcel/watcher": true
   core-js: true

--- a/scripts/syncPluginVersion.mjs
+++ b/scripts/syncPluginVersion.mjs
@@ -1,0 +1,27 @@
+import { readFileSync, writeFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
+const root = fileURLToPath(new URL('..', import.meta.url))
+
+const manifests = [
+  { packageJson: 'tools/claude/package.json', manifest: 'tools/claude/.claude-plugin/plugin.json' },
+  { packageJson: 'tools/cursor/package.json', manifest: 'tools/cursor/.cursor-plugin/plugin.json' },
+]
+
+for (const { packageJson, manifest } of manifests) {
+  const { version } = JSON.parse(readFileSync(`${root}${packageJson}`, 'utf-8'))
+  const manifestPath = `${root}${manifest}`
+  const manifestText = readFileSync(manifestPath, 'utf-8')
+  const currentVersion = JSON.parse(manifestText).version
+
+  if (currentVersion === version) {
+    console.log(`${manifest} is already at ${version}`)
+    continue
+  }
+
+  // A targeted replace keeps the file's existing formatting (single-line arrays, key
+  // order) intact instead of re-serializing the whole document.
+  const updated = manifestText.replace(/"version":\s*"[^"]*"/, `"version": "${version}"`)
+  writeFileSync(manifestPath, updated)
+  console.log(`Synced ${manifest} to ${version}`)
+}

--- a/scripts/syncPluginVersion.mjs
+++ b/scripts/syncPluginVersion.mjs
@@ -1,4 +1,5 @@
 import { readFileSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 const root = fileURLToPath(new URL('..', import.meta.url))
@@ -9,8 +10,8 @@ const manifests = [
 ]
 
 for (const { packageJson, manifest } of manifests) {
-  const { version } = JSON.parse(readFileSync(`${root}${packageJson}`, 'utf-8'))
-  const manifestPath = `${root}${manifest}`
+  const { version } = JSON.parse(readFileSync(join(root, packageJson), 'utf-8'))
+  const manifestPath = join(root, manifest)
   const manifestText = readFileSync(manifestPath, 'utf-8')
   const currentVersion = JSON.parse(manifestText).version
 

--- a/tools/claude/package.json
+++ b/tools/claude/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@stijnvanhulle/template-claude-plugin",
+  "version": "0.2.0",
+  "private": true,
+  "description": "Claude Code plugin for this template (agents, commands, skills, output styles).",
+  "license": "MIT"
+}

--- a/tools/cursor/package.json
+++ b/tools/cursor/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@stijnvanhulle/template-cursor-plugin",
+  "version": "0.2.0",
+  "private": true,
+  "description": "Cursor plugin for this template (agents, commands, rules, skills).",
+  "license": "MIT"
+}


### PR DESCRIPTION
## 🎯 Changes

`tools/claude/.claude-plugin/plugin.json` and `tools/cursor/.cursor-plugin/plugin.json` carried hand-typed `version` fields, bumped manually per the convention in `AGENTS.md`. This wires both into the existing Changesets flow instead:

- Add `tools/claude/package.json` and `tools/cursor/package.json` as private workspace packages (`@stijnvanhulle/template-claude-plugin`, `@stijnvanhulle/template-cursor-plugin`). Both match the existing `fixed: [["@stijnvanhulle/template-*"]]` group, so they bump in lockstep with every other package.
- Add `tools/*` to `pnpm-workspace.yaml`. The root `build`/`lint`/`typecheck` scripts stay scoped to `./packages/*`/`./internals/*`, so this doesn't pull the plugins into those pipelines.
- Add `"privatePackages": { "version": true, "tag": false }` to `.changeset/config.json` so Changesets versions private packages (off by default). `private: true` already keeps them out of `changeset publish`.
- Add `scripts/syncPluginVersion.mjs` and a `sync:plugin-version` script that copies each package's bumped version into its `plugin.json`'s `version` field with a targeted string replace, preserving formatting.
- Pass `version-script: pnpm exec changeset version && pnpm run sync:plugin-version` to `changesets/action` in the release workflow, and add `tools/claude/**` and `tools/cursor/**` to its trigger paths.
- Update `AGENTS.md` (regenerating `GEMINI.md` to match): the Claude and Cursor manifests are now Changesets-managed, never hand-edited. `.codex-plugin/plugin.json` and `gemini-extension.json` stay on the manual bump-together convention until they get a workspace package of their own.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](../CONTRIBUTING.md).
- [x] I ran the full pre-PR check locally: `pnpm format && pnpm lint:fix && pnpm typecheck && pnpm test`.
- [x] `pnpm agent-files` passes (regenerated `GEMINI.md`).

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is for the docs (no release).

No changeset needed for this PR: it only wires up the versioning mechanism, it doesn't change either plugin's own content or version.

## Test plan

- [x] `pnpm install` — both new packages resolve as workspace members.
- [x] `pnpm exec changeset status` with a throwaway changeset — both packages correctly join the `@stijnvanhulle/template-*` fixed bump group.
- [x] Ran `scripts/syncPluginVersion.mjs` against bumped test versions for both packages — confirmed it updates only the `version` field in each `plugin.json` and leaves formatting untouched.
- [ ] End-to-end on a real release.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WLr4jmn9i3sqZwe9372Xr5)_