### PR TITLE
fix(ci): stop chaining commands in changesets/action version-script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,9 @@ jobs:
         with:
           # Keeps the Claude and Cursor plugin manifests' version fields in step with
           # the @stijnvanhulle/template-{claude,cursor}-plugin packages Changesets bumps.
-          version-script: pnpm exec changeset version && pnpm run sync:plugin-version
+          # changesets/action runs this without a shell, so `&&` can't chain
+          # commands here — pnpm run does its own shell chaining instead.
+          version-script: pnpm run release:version
           publish-script: pnpm release
           commit-message: 'ci(changesets): version packages'
           pr-title: 'ci(changesets): version packages'

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "lint": "oxlint -c oxlint.config.ts ./packages",
     "lint:fix": "oxlint -c oxlint.config.ts --fix ./packages",
     "release": "changeset publish",
+    "release:version": "changeset version && pnpm run sync:plugin-version",
     "start": "turbo run start --filter=./packages/* --filter=./internals/*",
     "sync:plugin-version": "node scripts/syncPluginVersion.mjs",
     "test": "vitest run --config ./configs/vitest.config.ts",


### PR DESCRIPTION
## 🎯 Changes

Fixes the same Release-workflow bug reported in `kubb-labs/kubb`: `changesets/action` runs `version-script` through `@actions/exec`, which does not spawn a shell. This repo's `version-script: pnpm exec changeset version && pnpm run sync:plugin-version` would fail the same way, `&&` gets tokenized as a literal argument and passed to the `changeset version` CLI instead of chaining two commands.

Fix: move the chain into a new `release:version` pnpm script (`changeset version && pnpm run sync:plugin-version`), which pnpm runs through a real shell, and point `version-script` at `pnpm run release:version`.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](../CONTRIBUTING.md).
- [x] I ran the full pre-PR check locally: `pnpm format && pnpm lint:fix && pnpm typecheck && pnpm test`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is for the docs (no release).

Only CI config and the root `package.json` scripts changed; no published package changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TSjgfZiACKnAwUKVwgDqzk

---
_Generated by [Claude Code](https://claude.ai/code/session_01TSjgfZiACKnAwUKVwgDqzk)_