### PR TITLE
ci: add comment ratio check to PR workflow

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -171,3 +171,25 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           build-script: 'build'
           pattern: './packages/*/dist/**/*.{js,mjs,cjs}'
+
+  comment-ratio:
+    name: Comment ratio
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    if: github.actor != 'github-actions[bot]' && github.event_name == 'pull_request'
+    steps:
+      - name: Check out code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Check comment ratio
+        uses: IgnaceMaes/comment-ratio@8667d710c02c19dcca42be02f97d5f6824012932 # v1.0.0
+        with:
+          max-comment-ratio: 0.15
+          exclude: |
+            **/__snapshots__/**


### PR DESCRIPTION
## 🎯 Changes

Adds the [comment-ratio](https://github.com/marketplace/actions/comment-ratio) action as a `Comment ratio` job in `.github/workflows/pr.yml`. The job counts the code and comment lines a pull request adds and fails when comments take up more than their share, which keeps agent-written code from over-narrating itself.

This matches the job added to `kubb-labs/kubb`, `kubb-labs/plugins`, and `kubb-labs/platform`, so a fork of this template starts with the same check.

Settings:

- `max-comment-ratio: 0.15` instead of the action default of `0.05`. The `jsdoc` rule asks for a doc comment on every exported type, property, and function, and each one is a multi-line `/** ... */` block. At 5% a normal PR that adds a documented export would fail.
- `exclude: **/__snapshots__/**` so Vitest snapshots do not count.
- The job runs only on `pull_request`, since the action needs a base and head to compare and `pr.yml` also runs on `workflow_dispatch`.
- The action is pinned to commit `8667d710c02c19dcca42be02f97d5f6824012932` (`v1.0.0`), matching how every other action in this repo is pinned.
- Checkout keeps `persist-credentials: false`, like every other job here. The action resolves the merge base through the API with `github.token`, so it does not need git credentials on disk.

Markdown and other prose formats are excluded by the action itself, so `GEMINI.md` regeneration and docs edits do not affect the ratio.

To verify: open any pull request and check the `Comment ratio` job. It writes a job summary and keeps one sticky comment on the pull request up to date. On the three repos where this already ran, it reported "Skipped — below the minimum of 50 lines added" for a change this size.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](../CONTRIBUTING.md).
- [ ] I ran the full pre-PR check locally: `pnpm format && pnpm lint:fix && pnpm typecheck && pnpm test`. CI-only change touching one YAML file; the workflow was validated by parsing it.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is for the docs (no release). CI configuration only. It touches no workspace package and nothing shipped in the Claude, Cursor, Codex, or Gemini toolkit manifests, so no changeset and no manifest version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HCDYwCk67B1eS6314fHqXc

---
_Generated by [Claude Code](https://claude.ai/code/session_01HCDYwCk67B1eS6314fHqXc)_