### PR TITLE
docs(claude): document how to install and switch output styles

### DIFF
--- a/tools/claude/README.md
+++ b/tools/claude/README.md
@@ -77,6 +77,36 @@ Rules need no trigger. `plain-language`, `security`, and `usa-english` apply on 
 and the rest attach when you open a matching file. The guiding split: rules apply on their own,
 skills are optional expertise loaded when relevant, and commands are actions you trigger yourself.
 
+## Output styles
+
+Installing the plugin already registers the three output styles (`house`, `plan`,
+`diagrams-first`) for every session. Switch between them from inside a session:
+
+```bash
+/output-style house
+/output-style plan
+/output-style diagrams-first
+```
+
+To use `house` without installing the plugin, copy the file into your user-wide output
+styles folder:
+
+```bash
+mkdir -p ~/.claude/output-styles
+curl -fsSL https://raw.githubusercontent.com/stijnvanhulle/template/main/tools/claude/output-styles/house.md \
+  -o ~/.claude/output-styles/house.md
+```
+
+Then set it as your default in `~/.claude/settings.json`:
+
+```json
+{
+  "outputStyle": "house"
+}
+```
+
+Restart Claude Code, or run `/output-style house` in an open session, to pick it up.
+
 ## Scope
 
 The plugin ships generic, project-agnostic content. Workspace-specific pieces


### PR DESCRIPTION
## 🎯 Changes

Adds an "Output styles" section to `tools/claude/README.md` covering:

- Switching between the plugin's three output styles (`house`, `plan`, `diagrams-first`) with `/output-style` once the plugin is installed.
- Installing `house` user-wide without the plugin, by copying `tools/claude/output-styles/house.md` into `~/.claude/output-styles/`.
- Setting it as the default via `outputStyle` in `~/.claude/settings.json`.

## 🧪 How to test

- Step 1: Open `tools/claude/README.md`.
- Step 2: Read the new "Output styles" section.
- Step 3: The `curl` command and `settings.json` snippet match the file paths in `tools/claude/output-styles/`.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](../CONTRIBUTING.md).
- [x] I ran the full pre-PR check locally: `pnpm format && pnpm lint:fix && pnpm typecheck && pnpm test`. (`typecheck` failed in this sandbox with an unrelated `Exec format error` from the toolchain binary; this PR only touches a markdown file.)

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is for the docs (no release).
- [ ] This change is breaking, and the body says what breaks and what a user has to do.

https://claude.ai/code/session_01L49qgYtp9kEHdVco15XMWr

---
_Generated by [Claude Code](https://claude.ai/code/session_01L49qgYtp9kEHdVco15XMWr)_